### PR TITLE
Watch out: Semantics of BlockFactory.SetPosition() has changed

### DIFF
--- a/Assets/SEECity/Layout/BalloonLayout.cs
+++ b/Assets/SEECity/Layout/BalloonLayout.cs
@@ -106,22 +106,6 @@ namespace SEE.Layout
             DrawPlane(roots, max_radius);
         }
 
-        // Just for experimentation of SetPosition.
-        private void DrawBlocks()
-        {
-            {
-                CubeFactory factory = new CubeFactory();
-                GameObject block = factory.NewBlock();
-                factory.SetPosition(block, Vector3.zero);
-            }
-
-            {
-                BuildingFactory factory = new BuildingFactory();
-                GameObject block = factory.NewBlock();
-                factory.SetPosition(block, Vector3.zero);
-            }
-        }
-
         /// <summary>
         /// The maximal depth of the node hierarchy.
         /// </summary>

--- a/Assets/SEECity/Layout/BlockFactory.cs
+++ b/Assets/SEECity/Layout/BlockFactory.cs
@@ -81,16 +81,13 @@ namespace SEE.Layout
         public abstract void ScaleBlock(GameObject block, Vector3 scale);
 
         /// <summary>
-        /// Sets the position of the current block. The given position is interpreted
-        /// as the center of the block.
+        /// Sets the position of the current block. The given x and z positions are interpreted
+        /// as the center of the block and the y co-ordinate specifies the ground level of the 
+        /// block.
         /// </summary>
         /// <param name="block">block to be positioned</param>
         /// <param name="position">where to position the block</param>
-        public virtual void SetPosition(GameObject block, Vector3 position)
-        {
-            // the default position of a game object in Unity is its center
-            block.transform.position = position;
-        }
+        public abstract void SetPosition(GameObject block, Vector3 position);
 
         /// <summary>
         /// Returns the center of the roof of the given block.

--- a/Assets/SEECity/Layout/BuildingFactory.cs
+++ b/Assets/SEECity/Layout/BuildingFactory.cs
@@ -148,6 +148,7 @@ namespace SEE.Layout
                 buildingModifier.buildingDepth = 5;
                 buildingModifier.useAdvertising = true;
                 buildingModifier.useGraffiti = true;
+                buildingModifier.extendFoundations = 0.0f;
                 buildingModifier.AwakeCity();
                 buildingModifier.UpdateCity();
             }

--- a/Assets/SEECity/Layout/CubeFactory.cs
+++ b/Assets/SEECity/Layout/CubeFactory.cs
@@ -159,6 +159,19 @@ namespace SEE.Layout
         {
             block.transform.localScale = scale;
         }
+
+        public override void SetPosition(GameObject block, Vector3 position)
+        {
+            // The default position of a game object in Unity is its center.
+            // Thus, the x and z co-ordinates are just fine. Yet, the y co-ordinate
+            // needs adjustment. position.y specifies the ground level of the block,
+            // whereas block.transform.position.y is assumed to be height center of a 
+            // game object by Unity. As a consequence, we need to lift position.y
+            // by half of the block's height. 
+
+            Vector3 size = GetSize(block);
+            block.transform.position = new Vector3(position.x, size.y / 2.0f, position.z);
+        }
     }
 }
 

--- a/Assets/SEECity/Layout/ILayout.cs
+++ b/Assets/SEECity/Layout/ILayout.cs
@@ -84,6 +84,11 @@ namespace SEE.Layout
         protected bool showErosions;
 
         /// <summary>
+        /// The y co-ordinate of the ground where blocks are placed.
+        /// </summary>
+        protected const float groundLevel = 0.0f;
+
+        /// <summary>
         /// Returns the default material for edges using the materialPath.
         /// </summary>
         /// <returns>default material for edges</returns>

--- a/Assets/SEECity/Layout/ManhattenLayout.cs
+++ b/Assets/SEECity/Layout/ManhattenLayout.cs
@@ -77,9 +77,8 @@ namespace SEE.Layout
                     
                     positionX += size.x / 2.0f;
                     // The position is the center of a GameObject. We want all GameObjects
-                    // be placed at the same ground level 0. That is why we need to "lift"
-                    // every building by half of its height.
-                    blockFactory.SetPosition(block, new Vector3(positionX, size.y / 2.0f, positionZ));
+                    // be placed at the same ground level 0. 
+                    blockFactory.SetPosition(block, new Vector3(positionX, groundLevel, positionZ));
 
                     positionX += size.x / 2.0f + distanceBetweenBuildings;
 


### PR DESCRIPTION
The y co-ordinate is now interpreted as the ground position of the block. This allows
us to unify cubes and CScape buildings.

Attribute extendFoundations is set to 0.0f for CScape buildings. There are
some buildings where this attributes is actually used (not all of them
use it), in which case a piece of the building (its foundation) is added,
which is then below the ground level. That may be expected for real
buildings (the foundation is below the ground), but may confuse the
human beholder.