### PR TITLE
Interpolate path in ScriptedCamera with a CatmullRom spline.

### DIFF
--- a/Assets/Camera/ScriptedCamera.cs
+++ b/Assets/Camera/ScriptedCamera.cs
@@ -119,15 +119,15 @@ namespace SEE
                 pathIsEnabled = false;
                 return;
             }
-            if (path.Count < 2)
+            if (path.Count < 1)
             {
-                Debug.LogWarning("ScriptedCamera: Requiring at least two locations.\n");
+                Debug.LogWarning("ScriptedCamera: Requiring at least one location.\n");
                 pathIsEnabled = false;
                 return;
             }
             try
             {
-                spline = TinySpline.BSpline.InterpolateCubic(VectorsToList(path), 4);
+                spline = TinySpline.BSpline.InterpolateCatmullRom(VectorsToList(path), 4);
                 pathIsEnabled = true;
             }
             catch (Exception e)


### PR DESCRIPTION
As already mentioned in PR #67, TinySpline can now interpolate (Centripetal) CatmullRom splines. These kinds of splines are better suited for interpolating movement paths.

I recorded a path with the `CameraPosition.cs` script and visualized the path drawn  by `CameraPath.Draw()` (magenta), the interpolated spline of `BSpline.InterpolateCubic` (green), and the interpolated spline of `BSpline.InterpolateCatmullRom` (red). As you can see in the first figure, CatmullRom splines (in most cases)  follow the interpolated points more closely. In the second figure you can see that there may be cases where cubic splines create self-intersections (this is not a bug). CatmullRom splines interpolated by TinySpline cannot have such self-intersections (if the `alpha` parameter is 0.5, which is the default value).

![catmullrom1](https://user-images.githubusercontent.com/317428/79070152-a68ee300-7c88-11ea-915c-fb81be5aa883.png)

![catmullrom2](https://user-images.githubusercontent.com/317428/79070149-a55db600-7c88-11ea-9fa7-425ed25aa65a.png)

Unlike cubic splines, CatmullRom splines are only piecewise cubic. That is, they are not cubic (in fact they are C^1 continuous) at their join points (the interpolated points). That said, if you want to visualize splines, I would stick with cubic splines because they are more visually appealing due to being C^2 continuous in all points.
