### PR TITLE
Avoiding UnityEngine.Object.FindObjectOfType on each Update cycle

### DIFF
--- a/Assets/SEE/Utils/Raycasting.cs
+++ b/Assets/SEE/Utils/Raycasting.cs
@@ -36,12 +36,26 @@ namespace SEE.Utils
         }
 
         /// <summary>
+        /// The cached event system. It is cached because it needs to be queried in
+        /// each Update cycle.
+        /// </summary>
+        private static EventSystem eventSystem;
+
+        /// <summary>
         /// Whether the mouse currently hovers over a GUI element.
         /// </summary>
         /// <returns>Whether the mouse currently hovers over a GUI element.</returns>
         public static bool IsMouseOverGUI()
         {
-            return UnityEngine.Object.FindObjectOfType<EventSystem>().IsPointerOverGameObject();
+            if (eventSystem == null)
+            {
+                eventSystem = UnityEngine.Object.FindObjectOfType<EventSystem>();
+                if (eventSystem == null)
+                {
+                    throw new System.Exception("No EventSystem found.");
+                }
+            }
+            return eventSystem.IsPointerOverGameObject();
         }
     }
 }


### PR DESCRIPTION
The event system is cached so that the expensive call to UnityEngine.Object.FindObjectOfType on each Update cycle can be avoided.