### PR TITLE
Verify no rendered code cities are committed

### DIFF
--- a/generateHook.bat
+++ b/generateHook.bat
@@ -17,13 +17,13 @@ ECHO while IFS= read -r scene
 ECHO do
 ECHO         if [ -n "$scene" ]; then
 ECHO                 output="$output
-ECHO Warnung: Ungelöschte CodeCity-Knoten erkannt in Szene '$scene'!"
+ECHO Warning: Rendered CodeCities detected in scene '$scene'!"
 ECHO         fi
 ECHO done ^<^< EOF
 ECHO $(git diff --staged -S"m_TagString: Node" --name-only Assets/Scenes 2^> /dev/null^)
 ECHO EOF
 ECHO if [ -n "$output" ]; then
-ECHO         printf '%%s\nBitte alle gezeichneten CodeCities vor dem Commit löschen.' "$output"
+ECHO         printf '%%s\nPlease delete all drawn CodeCities before committing.' "$output"
 ECHO         exit 1
 ECHO fi
 ECHO exit 0

--- a/generateHook.sh
+++ b/generateHook.sh
@@ -16,14 +16,14 @@ while IFS= read -r scene
 do
         if [ -n "\$scene" ]; then
                 output="\$output
-Warnung: Ungelöschte CodeCity-Knoten erkannt in Szene '\$scene'!"
+Warning: Rendered CodeCities detected in scene '\$scene'!"
         fi
 done << EOF
 \$(git diff --staged -S"m_TagString: Node" --name-only Assets/Scenes 2> /dev/null)
 EOF
 
 if [ -n "\$output" ]; then
-        printf '%s\nBitte alle gezeichneten CodeCities vor dem Commit löschen.' "\$output"
+        printf '%s\nPlease delete all drawn CodeCities before committing.' "\$output"
         exit 1
 fi
 exit 0


### PR DESCRIPTION
Two new scripts have been added for Windows and Linux/Mac OS respectively, `generateHook.bat` and `generateHook.sh`.
When run, these will install a third script to the `.git/hooks` directory which aborts the commit with a corresponding warning about undeleted code cities, if there are any.