### PR TITLE
Fix Tooltip (& other UI components) logging exceptions when disabling them

### DIFF
--- a/Assets/SEE/Game/UI/CodeWindow/CodeSpace.cs
+++ b/Assets/SEE/Game/UI/CodeWindow/CodeSpace.cs
@@ -106,7 +106,10 @@ namespace SEE.Game.UI.CodeWindow
                 codeWindow.enabled = false;
             }
 
-            space?.SetActive(false);
+            if (space != null)
+            {
+                space.SetActive(false);
+            }
         }
 
         /// <summary>
@@ -120,7 +123,10 @@ namespace SEE.Game.UI.CodeWindow
                 codeWindow.enabled = true;
             }
 
-            space?.SetActive(true);
+            if (space)
+            {
+                space.SetActive(true);
+            }
         }
 
         /// <summary>

--- a/Assets/SEE/Game/UI/PropertyDialog/PropertyDialog.cs
+++ b/Assets/SEE/Game/UI/PropertyDialog/PropertyDialog.cs
@@ -109,7 +109,11 @@ namespace SEE.Game.UI.PropertyDialog
         /// <param name="value">whether enabling or disabling is requested</param>
         private void Enable(bool value)
         {
-            dialog?.SetActive(value);
+            if (dialog != null)
+            {
+                dialog.SetActive(value);
+            }
+
             foreach (PropertyGroup group in groups)
             {
                 group.enabled = value;

--- a/Assets/SEE/Game/UI/Tooltip/Tooltip.cs
+++ b/Assets/SEE/Game/UI/Tooltip/Tooltip.cs
@@ -159,12 +159,18 @@ namespace SEE.Game.UI.Tooltip
 
         private void OnDisable()
         {
-            tooltipGameObject?.SetActive(false);
+            if (tooltipGameObject != null)
+            {
+                tooltipGameObject.SetActive(false);
+            }
         }
 
         private void OnEnable()
         {
-            tooltipGameObject?.SetActive(true);
+            if (tooltipGameObject != null)
+            {
+                tooltipGameObject.SetActive(true);
+            }
         }
 
         protected override void StartHoloLens()


### PR DESCRIPTION
The problem was caused by the null propagation syntax `?.` causing a bypass of the lifetime check of the underlying Unity object.
An explicit comparison with `!= null` has to be done.

For more information, see [this explanation by JetBrains](https://github.com/JetBrains/resharper-unity/wiki/Possible-unintended-bypass-of-lifetime-check-of-underlying-Unity-engine-object).