### PR TITLE
Calculation of the edges after scaling a node

### DIFF
--- a/Assets/SEE/Controls/Actions/AddEdgeAction.cs
+++ b/Assets/SEE/Controls/Actions/AddEdgeAction.cs
@@ -1,4 +1,4 @@
-﻿using Assets.SEE.Game;
+﻿using SEE.Game;
 using SEE.Game.UI.Notification;
 using SEE.GO;
 using SEE.Net;

--- a/Assets/SEE/Controls/Actions/ScaleNodeAction.cs
+++ b/Assets/SEE/Controls/Actions/ScaleNodeAction.cs
@@ -3,10 +3,10 @@ using SEE.GO;
 using SEE.Utils;
 using System;
 using UnityEngine;
-using Assets.SEE.Game;
 using System.Collections.Generic;
 using SEE.DataModel.DG;
 using SEE.DataModel;
+using System.Linq;
 
 namespace SEE.Controls.Actions
 {

--- a/Assets/SEE/Game/GameEdgeAdder.cs
+++ b/Assets/SEE/Game/GameEdgeAdder.cs
@@ -4,13 +4,13 @@ using SEE.GO;
 using System;
 using UnityEngine;
 
-namespace Assets.SEE.Game
+namespace SEE.Game
 {
     /// <summary>
     /// Creates new game objects representing graph edges or deleting these again,
     /// respectively.
     /// </summary>
-    class GameEdgeAdder
+    public class GameEdgeAdder
     {
         /// <summary>
         /// Creates and returns a new edge from <paramref name="source"/> to <paramref name="target"/>.

--- a/Assets/SEE/Net/Scripts/Actions/AddEdgeNetAction.cs
+++ b/Assets/SEE/Net/Scripts/Actions/AddEdgeNetAction.cs
@@ -1,4 +1,4 @@
-﻿using Assets.SEE.Game;
+﻿using SEE.Game;
 using UnityEngine;
 
 namespace SEE.Net

--- a/Assets/SEE/Net/Scripts/Actions/DeleteNetAction.cs
+++ b/Assets/SEE/Net/Scripts/Actions/DeleteNetAction.cs
@@ -1,5 +1,4 @@
-﻿using Assets.SEE.Game;
-using SEE.Game;
+﻿using SEE.Game;
 using SEE.GO;
 using UnityEngine;
 


### PR DESCRIPTION
The animation of the edges when scaling the nodes is simply realised via a recalculation in the update method. Alternatively, I have written a version in which only the liner renderer is manipulated, but this sometimes causes problems with the mesh collider, so I have decided to go this way.