### PR TITLE
#340 Potentially fixed thread bug

### DIFF
--- a/Assets/SEE/Net/Network.cs
+++ b/Assets/SEE/Net/Network.cs
@@ -120,9 +120,15 @@ namespace SEE.Net
         public static bool InternalLoggingEnabled => instance && instance.internalLoggingEnabled;
 #endif
 
+        /// <summary>
+        /// The Unity main thread. Note that we cannot initialize its value here
+        /// because the elaboration code initializing static attributes may be
+        /// executed by a thread different from Unity's main thread. This attribute
+        /// will be initialized in <see cref="Awake"/> for this reason.
+        /// </summary>
         private static Thread mainThread = null;
         /// <summary>
-        /// Contains the main thread of the application.
+        /// Contains the Unity main thread of the application.
         /// </summary>
         public static Thread MainThread
         {
@@ -134,7 +140,7 @@ namespace SEE.Net
             private set
             {
                 Assert.IsNull(mainThread, "The main Unity thread has already been determined!");
-                Assert.IsNotNull(value, "The main Unity thread can not be null!");
+                Assert.IsNotNull(value, "The main Unity thread must not be null!");
                 mainThread = value;
             }
         }
@@ -159,6 +165,10 @@ namespace SEE.Net
 
             instance = this;
 
+            /// The field <see cref="MainThread"/> is supposed to denote Unity's main thread.
+            /// The <see cref="Awake"/> function is guaranteed to be executed by Unity's main
+            /// thread, that is, <see cref="Thread.CurrentThread"/> represents Unity's 
+            /// main thread here.
             MainThread = Thread.CurrentThread;
 
             if (!useInOfflineMode)
@@ -210,7 +220,7 @@ namespace SEE.Net
                     }
                     else
                     {
-                        Util.Logger.LogError("Unsupported city-type!");
+                        Util.Logger.LogError("Unsupported city type!");
                     }
                 }
             }

--- a/Assets/SEE/Net/PacketHandler.cs
+++ b/Assets/SEE/Net/PacketHandler.cs
@@ -96,7 +96,9 @@ namespace SEE.Net
         {
             lock (serializedPendingPackets)
             {
-                // FIXME: Why this assert? It always fails.
+                // Some opertations can be executed only by the Unity main thread. That
+                // is why we need to make sure, the thread currently executing this code
+                // is actually the Unity main thread.
                 Assert.AreEqual(Thread.CurrentThread, Network.MainThread);
                 foreach (SerializedPendingPacket serializedPendingPacket in serializedPendingPackets)
                 {


### PR DESCRIPTION
Explanation: Networked messages must only be processed by the main Unity thread, because not every action in Unity can be multi-threaded. To determine the main thread, a static property was used and initialized in place. Unity potentially loads those in a different thread on start. Therefore, the main thread is now determined in the Awake-method instead, which is always called by the main Unity thread.