### PR TITLE
Fix various reflexion analysis bugs

### DIFF
--- a/Assets/SEE/Controls/Actions/MoveAction.cs
+++ b/Assets/SEE/Controls/Actions/MoveAction.cs
@@ -56,27 +56,27 @@ namespace SEE.Controls.Actions
             /// The root of the code city. This is the top-most game object representing a node,
             /// i.e., is tagged by <see cref="Tags.Node"/>.
             /// </summary>
-            internal Transform CityRootNode;
+            internal readonly Transform CityRootNode;
 
             /// <summary>
             /// The game object currently being hovered over. It is a descendant of <see cref="CityRootNode"/>
             /// or <see cref="CityRootNode"/> itself.
             /// </summary>
-            internal Transform HoveredObject;
+            internal readonly Transform HoveredObject;
 
             /// <summary>
             /// The interactable component attached to <see cref="HoveredObject"/>.
             /// </summary>
-            internal InteractableObject InteractableObject;
+            internal readonly InteractableObject InteractableObject;
 
             /// <summary>
             /// Map from connected edges represented as <see cref="SEESpline"/>s to a boolean
             /// representing whether <see cref="node"/> is the source for this edge (otherwise, it's the target).
             /// </summary>
-            internal IList<(SEESpline, bool nodeIsSource)> ConnectedEdges;
+            internal readonly IList<(SEESpline, bool nodeIsSource)> ConnectedEdges;
 
-            internal Plane Plane;
-            internal NodeRef node;
+            internal readonly Plane Plane;
+            internal readonly NodeRef node;
         }
 
         /// <summary>

--- a/Assets/SEE/Game/City/ReflexionVisualization.cs
+++ b/Assets/SEE/Game/City/ReflexionVisualization.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using SEE.DataModel;
 using SEE.DataModel.DG;
 using SEE.Game.Operator;
@@ -58,7 +59,7 @@ namespace SEE.Game.City
         private void Start()
         {
             // We have to set an initial color for the edges.
-            foreach (Edge edge in CityGraph.Edges())
+            foreach (Edge edge in CityGraph.Edges().Where(x => !x.HasToggle(Edge.IsVirtualToggle)))
             {
                 GameObject edgeObject = GraphElementIDMap.Find(edge.ID);
                 if (edgeObject != null && edgeObject.TryGetComponent(out SEESpline spline))

--- a/Assets/SEE/Game/SceneQueries.cs
+++ b/Assets/SEE/Game/SceneQueries.cs
@@ -242,10 +242,6 @@ namespace SEE.Game
         /// <summary>
         /// Retrieves the game object representing a node with the given <paramref name="nodeID"/>.
         ///
-        /// Note: This is an expensive operation as it traverses all objects in the scene.
-        /// FIXME: We may need to cache all this information in look up tables for better
-        /// performance.
-        ///
         /// Precondition: Such a game object actually exists.
         /// </summary>
         /// <param name="nodeID">the unique ID of the node to be retrieved</param>
@@ -253,22 +249,17 @@ namespace SEE.Game
         /// <exception cref="Exception">thrown if there is no such object</exception>
         public static GameObject RetrieveGameNode(string nodeID)
         {
-            foreach (GameObject gameNode in AllGameNodesInScene(true, true))
+            GameObject gameObject = GraphElementIDMap.Find(nodeID);
+            if (gameObject == null)
             {
-                if (gameNode.name == nodeID)
-                {
-                    return gameNode;
-                }
+                throw new Exception($"Node named {nodeID} not found.");
             }
-            throw new Exception($"Node named {nodeID} not found.");
+
+            return gameObject;
         }
 
         /// <summary>
         /// Retrieves the game object representing the given <paramref name="node"/>.
-        ///
-        /// Note: This is an expensive operation as it traverses all objects in the scene.
-        /// FIXME: We may need to cache all this information in look up tables for better
-        /// performance.
         ///
         /// Preconditions:
         ///   (1) <paramref name="node"/> is not null.
@@ -284,10 +275,6 @@ namespace SEE.Game
 
         /// <summary>
         /// Retrieves the game object representing the node referenced by the given <paramref name="nodeRef"/>.
-        ///
-        /// Note: This is an expensive operation as it traverses all objects in the scene.
-        /// FIXME: We may need to cache all this information in look up tables for better
-        /// performance.
         ///
         /// Preconditions:
         /// (1) <paramref name="nodeRef"/> must reference a valid node.

--- a/Assets/SEE/Tools/ReflexionAnalysis/Incremental.cs
+++ b/Assets/SEE/Tools/ReflexionAnalysis/Incremental.cs
@@ -45,7 +45,7 @@ namespace SEE.Tools.ReflexionAnalysis
                           () => new NotInSubgraphException(Implementation, from));
             AssertOrThrow(FullGraph.ContainsNode(to) && to.IsInImplementation(),
                           () => new NotInSubgraphException(Implementation, to));
-            Edge edge = AddEdge(from, to, type);
+            Edge edge = AddEdge(from, to, type, false);
             Notify(new EdgeEvent(edge, ChangeType.Addition, Implementation));
             PropagateAndLiftDependency(edge);
             return edge;
@@ -141,7 +141,7 @@ namespace SEE.Tools.ReflexionAnalysis
             AssertOrThrow(FullGraph.ContainsNode(to) && to.IsInArchitecture(),
                           () => new NotInSubgraphException(Architecture, to));
             AssertNotRedundant(from, to, type);
-            Edge edge = AddEdge(from, to, type);
+            Edge edge = AddEdge(from, to, type, true);
             SetState(edge, State.Specified);
             Notify(new EdgeEvent(edge, ChangeType.Addition, Architecture));
 

--- a/Assets/SEE/Tools/ReflexionAnalysis/ReflexionAnalysis.cs
+++ b/Assets/SEE/Tools/ReflexionAnalysis/ReflexionAnalysis.cs
@@ -1141,8 +1141,9 @@ namespace SEE.Tools.ReflexionAnalysis
         /// <param name="from">the source of the edge</param>
         /// <param name="to">the target of the edge</param>
         /// <param name="itsType">the type of the edge</param>
+        /// <param name="isVirtual">whether the new edge should be drawn in the scene</param>
         /// <returns>the new edge</returns>
-        private Edge AddEdge(Node from, Node to, string itsType)
+        private Edge AddEdge(Node from, Node to, string itsType, bool isVirtual)
         {
             // Note: a propagated edge between the same two architectural entities may be specified as well;
             // hence, we may have multiple edges in between.
@@ -1162,6 +1163,11 @@ namespace SEE.Tools.ReflexionAnalysis
             {
                 AssertOrThrow(to.IsInArchitecture(), () => new NotInSubgraphException(Architecture, to));
                 result.SetInArchitecture();
+            }
+
+            if (isVirtual)
+            {
+                result.SetToggle(Edge.IsVirtualToggle);
             }
 
             FullGraph.AddEdge(result);
@@ -1207,7 +1213,7 @@ namespace SEE.Tools.ReflexionAnalysis
             AssertOrThrow(alreadyPropagated == null, () => new AlreadyPropagatedException(alreadyPropagated, originatingEdge));
 
             const int counter = 1;
-            Edge propagatedArchitectureDep = AddEdge(archSource, archTarget, edgeType);
+            Edge propagatedArchitectureDep = AddEdge(archSource, archTarget, edgeType, true);
             // propagatedArchitectureDep is a propagated dependency in the architecture graph
             SetCounter(propagatedArchitectureDep, counter);
             propagationTable[propagatedArchitectureDep.ID] = originatingEdge;

--- a/Assets/SEE/Tools/ReflexionAnalysis/ReflexionGraphTools.cs
+++ b/Assets/SEE/Tools/ReflexionAnalysis/ReflexionGraphTools.cs
@@ -61,6 +61,7 @@ namespace SEE.Tools.ReflexionAnalysis
             {
                 Implementation => "Implementation",
                 Architecture => "Architecture",
+                None => null,
                 Mapping => null, // identified by edges' nodes
                 FullReflexion => null, // simply the whole graph
                 _ => throw new ArgumentOutOfRangeException(nameof(subgraph), subgraph, "Unknown subgraph type.")


### PR DESCRIPTION
After the changes from this PR, the `minilax` reflexion example is now drawn and handled correctly.
(At least insofar that no errors occur and the drawn reflexion city looks correct – I haven't verified whether the semantics are true.)