### PR TITLE
Only run CI once per branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Editmode tests


### PR DESCRIPTION
## Summary
Whenever a new commit is pushed onto a branch, any old CI runs for that branch will be cancelled. This way, only the most recent commit will be tested, and the runners won't be as occupied when pushing multiple commits one after another.