### PR TITLE
CI: Don't run approval/review code on master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,12 +67,16 @@ jobs:
       - uses: actions/github-script@v6
         name: Check for bad patterns
         with:
+          retries: 3
           script: |
             const PATTERNS = process.env.PATTERNS;
             const helper = require('./GitScripts/review_helper.js');
             if (PATTERNS === "none") {
               console.log("Found no bad patterns in changed files.");
-              await helper.approve(github, context, false);
+              if (context.ref !== 'refs/heads/master') {
+                // Not on master, but on PR: approve if necessary
+                await helper.approve(github, context, false);
+              }
             } else {
               let bad_patterns = PATTERNS.split('\n');
               console.log("::warning::Found " + Math.floor(bad_patterns.length/6) + " bad patterns!");

--- a/GitScripts/review_helper.js
+++ b/GitScripts/review_helper.js
@@ -66,6 +66,10 @@ module.exports = {
             repo: context.repo.repo,
             pull_number: context.issue.number
         });
+        if (response['data'].length == 0) {
+            // No reviews present, no need to approve.
+            return;
+        }
         let reviews = await github.paginate(response);
         reviews = reviews.filter(x => x['user']['login'] === "github-actions[bot]");
         const comments = await get_reviews(github, context);


### PR DESCRIPTION
This is a small fix to make sure we don't try to leave review comments on master (which is impossible, hence makes the pipeline fail outside of pull requests).