### PR TITLE
#574 GetLiblzmaPath() now makes a distinction whether run in editor other deployed application

### DIFF
--- a/Assets/SEE/DataModel/DG/IO/GraphReader.cs
+++ b/Assets/SEE/DataModel/DG/IO/GraphReader.cs
@@ -131,29 +131,13 @@ namespace SEE.DataModel.DG.IO
             else
             {
                 // In a deployed application, only the process architecture matters.
-                OSPlatform platform = GetOSPlatform();
-                switch (RuntimeInformation.ProcessArchitecture)
+                string arch = RuntimeInformation.ProcessArchitecture switch
                 {
-                    case Architecture.X86:
-                        libDir += "x86";
-                        break;
-                    case Architecture.X64:
-                        libDir += "x86_64";
-                        break;
-                    case Architecture.Arm when platform == OSPlatform.Windows:
-                        libDir += "x86";
-                        break;
-                    case Architecture.Arm64 when platform == OSPlatform.Windows:
-                        libDir += "x86_64";
-                        break;
-                    case Architecture.Arm:
-                        libDir += "x86";
-                        break;
-                    case Architecture.Arm64:
-                        libDir += "x86_64";
-                        break;
-                    default: throw new PlatformNotSupportedException($"Unknown architecture {RuntimeInformation.ProcessArchitecture}");
-                }
+                    Architecture.X86 or Architecture.Arm => "x86",
+                    Architecture.X64 or Architecture.Arm64 => "x86_64",
+                    _ => throw new PlatformNotSupportedException($"Unknown architecture {RuntimeInformation.ProcessArchitecture}"),
+                };
+                libDir = Path.Combine(libDir, arch);
             }
 
             string libPath = null;


### PR DESCRIPTION
This changes fixes problem #574 by making a distinction whether GetLiblzmaPath() is being run in the Unity editor or
in a deployed application.

I tested it on a Windows 64 bit computer in the editor and in a deployed application. I couldn't test it on other operating systems (Linux, OSX) or hardware architectures (e.g., 32 bit).

This closes #574.