### PR TITLE
Fixed Null error of Space Attribute in SyncWindowSpaceAction.cs

### DIFF
--- a/Assets/SEE/Game/UI/Window/BaseWindow.cs
+++ b/Assets/SEE/Game/UI/Window/BaseWindow.cs
@@ -188,7 +188,7 @@ namespace SEE.Game.UI.Window
     /// Used for serialization when sending a window over the network.
     /// </summary>
     [Serializable]
-    public abstract class WindowValues
+    public class WindowValues
     {
         /// <summary>
         /// Title of the window.

--- a/Assets/SEE/Net/Actions/SyncWindowSpaceAction.cs
+++ b/Assets/SEE/Net/Actions/SyncWindowSpaceAction.cs
@@ -1,16 +1,20 @@
-﻿using SEE.Controls;
+﻿using System;
+using SEE.Controls;
 using SEE.Game.UI.Window;
+using UnityEngine;
 
 namespace SEE.Net.Actions
 {
     /// <summary>
     /// Synchronizes the window spaces across all clients.
     /// </summary>
+    [Serializable]
     public class SyncWindowSpaceAction: AbstractNetAction
     {
         /// <summary>
         /// The value object of the window space which shall be transmitted over the network.
         /// </summary>
+        [field: SerializeField]
         private WindowSpace.WindowSpaceValues Space;
 
         /// <summary>


### PR DESCRIPTION
This is a small fix for an error in SyncWindowSpaceAction where the Space Attribute was Null when executing the Action.

This was because some classes weren't configured right for the Serializer.

Now the Attribute is Serialized correctly