### PR TITLE
CI: Detect missing EOF newlines and trailing whitespace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Collect bad patterns
         run: |
-          if [ -n $GITHUB_BASE_REF ] && ! PATTERNS=$(curl -H 'Accept: application/vnd.github.v3.diff' -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -f 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}' | grep '^[+@]' | ./GitScripts/check_for_bad_patterns.py); then
+          if [ -n $GITHUB_BASE_REF ] && ! PATTERNS=$(curl -H 'Accept: application/vnd.github.v3.diff' -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -f 'https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}' | ./GitScripts/check_for_bad_patterns.py); then
             DELIMITER=7MApgggGyx6C0
             echo "PATTERNS<<$DELIMITER" >> $GITHUB_ENV
             echo "$PATTERNS" >> $GITHUB_ENV

--- a/GitScripts/review_helper.js
+++ b/GitScripts/review_helper.js
@@ -44,7 +44,12 @@ module.exports = {
                     break;
                 case 4: // suggestion, if there is one.
                     if (patterns[i] !== '') {
-                        comment['body'] += `\n\n\`\`\`suggestion\n${patterns[i]}\n\`\`\``;
+                        var suggestion = patterns[i];
+                        if (suggestion.endsWith("\\n")) {
+                            // There may be a newline at the end, which we need to replace.
+                            suggestion = suggestion.replace(/\\n$/, "\n");
+                        }
+                        comment['body'] += `\n\n\`\`\`suggestion\n${suggestion}\n\`\`\``;
                     }
                     break;
                 case 5: // regex triggering this bad pattern


### PR DESCRIPTION
## Changes
This changes the `check_for_bad_patterns.py` script to detect both trailing whitespace within C# files and missing newlines at the end of a file. Whenever one of these is detected, a fitting suggestion to automatically fix this is shown as well.
This also required refactoring the Python script, as EOF newlines could not be detected on the previous approach. Additionally, a bug was fixed which incorrectly calculated line numbers.