### PR TITLE
CI Hotfix: Working build releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,8 +200,9 @@ jobs:
         run: |
           sudo /mnt/scripts/set-work-permissions.sh  # Permissions may be messed up here
           git reset --hard ${{ github.sha }}  # Test or previous build may have changed files
-          git clean -fd
-          rm -rf build || true  # Try deleting any previous build
+          # Try deleting any previous build, but not other zip files that we may need later.
+          git clean -fd -e 'build-*.zip'
+          rm -rf build "build-${{ matrix.targetPlatform }}.zip" || true
       - uses: game-ci/unity-builder@v2
         timeout-minutes: 45
         name: Build project
@@ -211,6 +212,7 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           buildName: ${{ matrix.targetPlatform }}
+          allowDirtyBuild: true
       - name: Compress build
         # Compress only if manually triggered or merged into master, otherwise we won't upload.
         if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged }}
@@ -228,7 +230,8 @@ jobs:
   release:
     name: Release
     runs-on: ${{ needs.setup.outputs.runner }}
-    needs: [build]
+    permissions: write-all
+    needs: [setup, build]
     # We only want to create a release after merging a PR into master.
     if: ${{ github.event.pull_request.merged }}
     steps:
@@ -248,6 +251,7 @@ jobs:
             build-*.zip
           body: |
             This release incorporates the changes by @${{ github.event.pull_request.user.login }} from pull request #${{ github.event.pull_request.number }}.
+            Builds for Windows and Linux are available below.
             
             ## Details
             ${{ github.event.pull_request.body }}


### PR DESCRIPTION
This fixes the following problems:
- Builds were unnecessarily compressed even if they were not going to be uploaded.
- Builds were cleaned before the release steps, leading to missing ZIP files.
- Write permissions for the release step were missing.
- A setup dependency for the release step was missing.

After this is merged, any merged PR should result in a new [release](https://github.com/uni-bremen-agst/SEE/releases) being created afterward, re-using the PR title and description, along with a built version of SEE for Windows and Linux.