### PR TITLE
CI: Upgrade to new version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
           restore-keys: |
             Library-SEE-Tests
             Library-SEE
-      - uses: game-ci/unity-test-runner@v2
+      - uses: game-ci/unity-test-runner@v3
         timeout-minutes: 45
         name: Run Tests
         id: tests
@@ -212,7 +212,7 @@ jobs:
           # Try deleting any previous build, but not other zip files that we may need later.
           git clean -fd -e 'build-*.zip'
           rm -rf build "build-${{ matrix.targetPlatform }}.zip" || true
-      - uses: game-ci/unity-builder@v2
+      - uses: game-ci/unity-builder@v3
         timeout-minutes: 45
         name: Build project
         id: build


### PR DESCRIPTION
The CI seems not to work anymore.
This hopefully fixes it, but we should wait until the pipeline was successful.