### PR TITLE
Scrollable PopupMenu and Bugfixes

### DIFF
--- a/Assets/Resources/Prefabs/UI/PopupMenu.prefab
+++ b/Assets/Resources/Prefabs/UI/PopupMenu.prefab
@@ -1,5 +1,41 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1663019024582587232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5211228808745714304}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5211228808745714304
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1663019024582587232}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9065995210227607972}
+  m_Father: {fileID: 1277190175664758981}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -10, y: -10}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2119300210375125840
 GameObject:
   m_ObjectHideFlags: 0
@@ -96,6 +132,284 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &2646598723003466407
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1277190175664758981}
+  - component: {fileID: 6560381920030770085}
+  - component: {fileID: 6114475630110519974}
+  - component: {fileID: 1317461013425925960}
+  m_Layer: 5
+  m_Name: Scrollbar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1277190175664758981
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2646598723003466407}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5936875154459080340}
+  - {fileID: 5211228808745714304}
+  m_Father: {fileID: 2849598639207669354}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 2.079956, y: 0}
+  m_SizeDelta: {x: 30, y: 0}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &6560381920030770085
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2646598723003466407}
+  m_CullTransparentMesh: 0
+--- !u!114 &6114475630110519974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2646598723003466407}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0.78431374}
+    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 0.9607843}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 0.9607843}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 0.39215687}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6197834639708925417}
+  m_HandleRect: {fileID: 9065995210227607972}
+  m_Direction: 2
+  m_Value: 0
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1317461013425925960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2646598723003466407}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e098a0a519700eb4094ec2c8b9d07b30, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UIManagerAsset: {fileID: 11400000, guid: 2a619a9609984be49b53b928dd94e61b, type: 2}
+  webglMode: 0
+  background: {fileID: 154694579477665696}
+  bar: {fileID: 6197834639708925417}
+--- !u!1 &3711954631907751104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7268603804443373351}
+  - component: {fileID: 8021736921224333860}
+  - component: {fileID: 671834660698726218}
+  - component: {fileID: 174800464467925275}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7268603804443373351
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3711954631907751104}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8263248321968212994}
+  m_Father: {fileID: 2849598639207669354}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &8021736921224333860
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3711954631907751104}
+  m_CullTransparentMesh: 1
+--- !u!114 &671834660698726218
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3711954631907751104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &174800464467925275
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3711954631907751104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!1 &4444420432707503559
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5936875154459080340}
+  - component: {fileID: 5915756417722097767}
+  - component: {fileID: 154694579477665696}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5936875154459080340
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4444420432707503559}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1277190175664758981}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -10, y: -10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5915756417722097767
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4444420432707503559}
+  m_CullTransparentMesh: 0
+--- !u!114 &154694579477665696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4444420432707503559}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.09803922}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5618123237d1d3f49a5a6025287065f7, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 15
 --- !u!1 &4894868454031714346
 GameObject:
   m_ObjectHideFlags: 0
@@ -127,12 +441,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5912560621427071452}
+  m_Father: {fileID: 7268603804443373351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 125, y: 0}
-  m_SizeDelta: {x: 250, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 137, y: 0}
+  m_SizeDelta: {x: 273, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &5339046660961053175
 CanvasRenderer:
@@ -278,6 +592,210 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &6372040685831296390
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2849598639207669354}
+  - component: {fileID: 8856059152711898015}
+  - component: {fileID: 4231571670373405360}
+  - component: {fileID: 7801428195907746336}
+  - component: {fileID: 1147030408212747452}
+  m_Layer: 5
+  m_Name: Scroll View
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2849598639207669354
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372040685831296390}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7268603804443373351}
+  - {fileID: 1277190175664758981}
+  m_Father: {fileID: 5912560621427071452}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8856059152711898015
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372040685831296390}
+  m_CullTransparentMesh: 1
+--- !u!114 &4231571670373405360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372040685831296390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7801428195907746336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372040685831296390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 8263248321968212994}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 1
+  m_Elasticity: 0
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 2
+  m_Viewport: {fileID: 7268603804443373351}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 6114475630110519974}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: -29.5
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1147030408212747452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372040685831296390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &8279598797200120626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9065995210227607972}
+  - component: {fileID: 7202998919532245725}
+  - component: {fileID: 6197834639708925417}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9065995210227607972
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8279598797200120626}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5211228808745714304}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7202998919532245725
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8279598797200120626}
+  m_CullTransparentMesh: 0
+--- !u!114 &6197834639708925417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8279598797200120626}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5618123237d1d3f49a5a6025287065f7, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 15
 --- !u!1 &8571083421594273759
 GameObject:
   m_ObjectHideFlags: 0
@@ -313,13 +831,13 @@ RectTransform:
   m_Children:
   - {fileID: 7501504874030521457}
   - {fileID: 2171780777662563463}
-  - {fileID: 8263248321968212994}
+  - {fileID: 2849598639207669354}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 0}
+  m_SizeDelta: {x: 273, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &4852780573510983347
 CanvasRenderer:

--- a/Assets/Resources/Prefabs/UI/PopupMenuButton.prefab
+++ b/Assets/Resources/Prefabs/UI/PopupMenuButton.prefab
@@ -331,8 +331,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 17.5, y: 0}
-  m_SizeDelta: {x: -55, y: 0}
+  m_AnchoredPosition: {x: 10, y: 0}
+  m_SizeDelta: {x: -70, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5059500120611322657
 CanvasRenderer:

--- a/Assets/Resources/Prefabs/UI/PopupMenuHeading.prefab
+++ b/Assets/Resources/Prefabs/UI/PopupMenuHeading.prefab
@@ -129,7 +129,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_margin: {x: 5, y: 0, z: 23, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0

--- a/Assets/SEE/Controls/Actions/ContextMenuAction.cs
+++ b/Assets/SEE/Controls/Actions/ContextMenuAction.cs
@@ -82,7 +82,7 @@ namespace SEE.Controls.Actions
 
             if (gameObject != null)
             {
-                actions.Add(new("Highlight", Highlight, Icons.LightBulb));
+                actions.Add(new("Show in City", Highlight, Icons.LightBulb));
             }
 
             if (graphElement.Filename() != null)

--- a/Assets/SEE/Controls/Actions/ShowTree.cs
+++ b/Assets/SEE/Controls/Actions/ShowTree.cs
@@ -30,7 +30,7 @@ namespace SEE.Controls.Actions
         /// <summary>
         /// Displays the tree view window for each code city.
         /// </summary>
-        private void ShowCodeView()
+        private void ShowTreeView()
         {
             GameObject[] cities = GameObject.FindGameObjectsWithTag(Tags.CodeCity);
             if (cities.Length == 0)
@@ -47,9 +47,9 @@ namespace SEE.Controls.Actions
                     {
                         continue;
                     }
-                    if (!gameObject.TryGetComponent(out TreeWindow window))
+                    if (!cityObject.TryGetComponent(out TreeWindow window))
                     {
-                        window = gameObject.AddComponent<TreeWindow>();
+                        window = cityObject.AddComponent<TreeWindow>();
                         window.Graph = city.LoadedGraph;
                     }
                     treeWindows.Add(city.name, window);
@@ -80,7 +80,7 @@ namespace SEE.Controls.Actions
         /// Close all tree view windows.
         /// It is assumed that this method is called from a toggle action.
         /// </summary>
-        private void HideCodeView()
+        private void HideTreeView()
         {
             // If none of the windows were actually closed, we should instead open them.
             bool anyClosed = false;
@@ -91,7 +91,7 @@ namespace SEE.Controls.Actions
             treeWindows.Clear();
             if (!anyClosed)
             {
-                ShowCodeView();
+                ShowTreeView();
             }
         }
 
@@ -101,11 +101,11 @@ namespace SEE.Controls.Actions
             {
                 if (treeWindows.Count == 0)
                 {
-                    ShowCodeView();
+                    ShowTreeView();
                 }
                 else
                 {
-                    HideCodeView();
+                    HideTreeView();
                 }
             }
         }

--- a/Assets/SEE/Controls/Actions/ShowTree.cs
+++ b/Assets/SEE/Controls/Actions/ShowTree.cs
@@ -1,4 +1,6 @@
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Cysharp.Threading.Tasks;
 using SEE.Game;
 using SEE.Game.City;
@@ -76,14 +78,21 @@ namespace SEE.Controls.Actions
 
         /// <summary>
         /// Close all tree view windows.
+        /// It is assumed that this method is called from a toggle action.
         /// </summary>
         private void HideCodeView()
         {
+            // If none of the windows were actually closed, we should instead open them.
+            bool anyClosed = false;
             foreach (string city in treeWindows.Keys)
             {
-                space.CloseWindow(treeWindows[city]);
+                anyClosed |= space.CloseWindow(treeWindows[city]);
             }
             treeWindows.Clear();
+            if (!anyClosed)
+            {
+                ShowCodeView();
+            }
         }
 
         private void Update()

--- a/Assets/SEE/Controls/WindowSpaceManager.cs
+++ b/Assets/SEE/Controls/WindowSpaceManager.cs
@@ -116,7 +116,7 @@ namespace SEE.Controls
                 }
 
                 // Close windows which are no longer open
-                closedWindows.ForEach(windowSpaces[playerName].CloseWindow);
+                closedWindows.ForEach(x => windowSpaces[playerName].CloseWindow(x));
 
                 // Set active window if it changed
                 if (windowSpaces[playerName].ActiveWindow.Title != valueObject.ActiveWindow.Title)

--- a/Assets/SEE/UI/PopupMenu/PopupMenu.cs
+++ b/Assets/SEE/UI/PopupMenu/PopupMenu.cs
@@ -33,7 +33,23 @@ namespace SEE.UI.PopupMenu
         /// <summary>
         /// The transform under which the entries are listed.
         /// </summary>
-        private RectTransform entryList;
+        private RectTransform actionList;
+
+        /// <summary>
+        /// The scroll view containing the popup items.
+        /// </summary>
+        private RectTransform scrollView;
+
+        /// <summary>
+        /// The scale factor of the canvas.
+        /// Should only be accessed through the <see cref="ScaleFactor"/> property.
+        /// </summary>
+        private float? scaleFactor;
+
+        /// <summary>
+        /// The scale factor of the canvas.
+        /// </summary>
+        private float ScaleFactor => scaleFactor ??= Canvas.MustGetComponent<Canvas>().scaleFactor;
 
         /// <summary>
         /// The content size fitter of the popup menu.
@@ -67,7 +83,8 @@ namespace SEE.UI.PopupMenu
             menu = (RectTransform)PrefabInstantiator.InstantiatePrefab(menuPrefabPath, Canvas.transform, false).transform;
             contentSizeFitter = menu.gameObject.MustGetComponent<ContentSizeFitter>();
             menuCanvasGroup = menu.gameObject.MustGetComponent<CanvasGroup>();
-            entryList = (RectTransform)menu.Find("Action List");
+            scrollView = (RectTransform)menu.Find("Scroll View");
+            actionList = (RectTransform)scrollView.Find("Viewport/Action List");
 
             // The menu should be hidden when the user moves the mouse away from it.
             PointerHelper pointerHelper = menu.gameObject.MustGetComponent<PointerHelper>();
@@ -89,8 +106,6 @@ namespace SEE.UI.PopupMenu
 
             // We hide the menu by default.
             menu.gameObject.SetActive(false);
-
-            // TODO (#679): Make this scrollable once it gets too big.
         }
 
         /// <summary>
@@ -126,7 +141,7 @@ namespace SEE.UI.PopupMenu
         /// <param name="action">The action to be added.</param>
         private void AddAction(PopupMenuAction action)
         {
-            GameObject actionItem = PrefabInstantiator.InstantiatePrefab("Prefabs/UI/PopupMenuButton", entryList, false);
+            GameObject actionItem = PrefabInstantiator.InstantiatePrefab("Prefabs/UI/PopupMenuButton", actionList, false);
             ButtonManagerBasic button = actionItem.MustGetComponent<ButtonManagerBasic>();
             button.buttonText = action.Name;
 
@@ -153,7 +168,7 @@ namespace SEE.UI.PopupMenu
         /// <param name="heading">The heading to be added.</param>
         private void AddHeading(PopupMenuHeading heading)
         {
-            GameObject headingItem = PrefabInstantiator.InstantiatePrefab("Prefabs/UI/PopupMenuHeading", entryList, false);
+            GameObject headingItem = PrefabInstantiator.InstantiatePrefab("Prefabs/UI/PopupMenuHeading", actionList, false);
             TextMeshProUGUI text = headingItem.MustGetComponent<TextMeshProUGUI>();
             text.text = heading.Text;
         }
@@ -181,7 +196,7 @@ namespace SEE.UI.PopupMenu
                 return;
             }
 
-            foreach (Transform child in entryList)
+            foreach (Transform child in actionList)
             {
                 Destroyer.Destroy(child.gameObject);
             }
@@ -193,11 +208,11 @@ namespace SEE.UI.PopupMenu
         /// <param name="position">The position to which the menu should be moved.</param>
         public void MoveTo(Vector2 position)
         {
-            float scaleFactor = Canvas.MustGetComponent<Canvas>().scaleFactor;
-            if (position.y < MenuHeight * scaleFactor)
+            AdjustMenuHeight();
+            if (position.y < MenuHeight * ScaleFactor)
             {
                 // If the menu is too close to the bottom of the screen, expand it upwards instead.
-                position.y += MenuHeight * scaleFactor;
+                position.y += MenuHeight * ScaleFactor;
                 // The mouse should hover over the first menu item already rather than being just outside of it,
                 // so we move the menu down and to the left a bit.
                 position += new Vector2(-5, -5);
@@ -209,6 +224,17 @@ namespace SEE.UI.PopupMenu
                 position += new Vector2(-5, 5);
             }
             menu.position = position;
+        }
+
+        /// <summary>
+        /// Adjusts the height of the menu (specifically, the scroll view) to fit the content
+        /// while ensuring that the menu does not take up more than 40% of the screen.
+        /// </summary>
+        private void AdjustMenuHeight()
+        {
+            // Menu should not take up more than 40% of the screen.
+            float height = Mathf.Clamp(actionList.sizeDelta.y, 100f, Screen.height / (2.5f*ScaleFactor));
+            scrollView.sizeDelta = new Vector2(scrollView.sizeDelta.x, height);
         }
 
         /// <summary>
@@ -226,6 +252,7 @@ namespace SEE.UI.PopupMenu
             contentSizeFitter.enabled = false;
             await UniTask.WaitForEndOfFrame();
             contentSizeFitter.enabled = true;
+            AdjustMenuHeight();
             await UniTask.WhenAll(menu.DOScale(1, animationDuration).AsyncWaitForCompletion().AsUniTask(),
                                   menuCanvasGroup.DOFade(1, animationDuration / 2).AsyncWaitForCompletion().AsUniTask());
         }

--- a/Assets/SEE/UI/Window/TreeWindow/TreeWindowContextMenu.cs
+++ b/Assets/SEE/UI/Window/TreeWindow/TreeWindowContextMenu.cs
@@ -245,15 +245,24 @@ namespace SEE.UI.Window.TreeWindow
                 entries.Add(new PopupMenuHeading("Items ordered by group count."));
             }
 
-            // These are the attributes we want to sort by for the time being. We might want to include
-            // all other attributes in the future, in which case the following code needs to be adapted.
-            entries.Add(SortActionFor("Source Name", x => x is Node node ? node.SourceName : null, false));
-            entries.Add(SortActionFor("Source Line", x => x.SourceLine(), true));
-            entries.Add(SortActionFor("Filename", x => x.Filename(), false));
+            // In addition to the type, we want to be able to sort by all existing numeric and string attributes.
             entries.Add(SortActionFor("Type", x => x.Type, false));
+            entries.AddRange(searcher.Graph.AllNumericAttributes().Select(NumericAttributeSortAction));
+            entries.AddRange(searcher.Graph.AllStringAttributes().Select(StringAttributeSortAction));
 
             contextMenu.ClearEntries();
             contextMenu.AddEntries(entries);
+            return;
+
+            PopupMenuAction NumericAttributeSortAction(string attributeKey)
+            {
+                return SortActionFor(attributeKey, x => x.TryGetNumeric(attributeKey, out float value) ? value : null, true);
+            }
+
+            PopupMenuAction StringAttributeSortAction(string attributeKey)
+            {
+                return SortActionFor(attributeKey, x => x.TryGetString(attributeKey, out string value) ? value : null, false);
+            }
         }
 
         /// <summary>
@@ -301,7 +310,8 @@ namespace SEE.UI.Window.TreeWindow
         {
             return (numeric, descending) switch
             {
-                (_, null) => ' ',
+                (true, null) => Icons.Hashtag,
+                (false, null) => Icons.Text,
                 (true, true) => Icons.SortNumericDown,
                 (true, false) => Icons.SortNumericUp,
                 (false, true) => Icons.SortAlphabeticalDown,

--- a/Assets/SEE/UI/Window/WindowSpace.cs
+++ b/Assets/SEE/UI/Window/WindowSpace.cs
@@ -89,16 +89,14 @@ namespace SEE.UI.Window
         /// </summary>
         /// <param name="window">The window which should be closed.</param>
         /// <exception cref="ArgumentNullException">If the given <paramref name="window"/> is <c>null</c>.</exception>
-        public void CloseWindow(BaseWindow window)
+        /// <returns><c>true</c> if the window was closed, <c>false</c> otherwise.</returns>
+        public bool CloseWindow(BaseWindow window)
         {
-            if (window == null)
+            if (ReferenceEquals(window, null))
             {
                 throw new ArgumentNullException(nameof(window));
             }
-            else if (windows.Contains(window))
-            {
-                windows.Remove(window);
-            }
+            return windows.Remove(window);
         }
 
         /// <summary>

--- a/Assets/SEE/Utils/Icons.cs
+++ b/Assets/SEE/Utils/Icons.cs
@@ -34,6 +34,8 @@ namespace SEE.Utils
         public const char SortAlphabeticalDown = '\uF15D';
         public const char SortNumericUp = '\uF163';
         public const char SortNumericDown = '\uF162';
+        public const char Hashtag = '#';
+        public const char Text = '\uF031';
         public const char EmptyRadio = '\uF111';
         public const char CheckedRadio = '\uF192';
         public const char CircleMinus = '\uF056';

--- a/Assets/SEETests/TestDashboard.cs
+++ b/Assets/SEETests/TestDashboard.cs
@@ -12,7 +12,7 @@ namespace SEETests
     /// <summary>
     /// Class which tests the dashboard retrieval, i.e. everything in the <see cref="SEE.Net.Dashboard"/> namespace.
     /// </summary>
-    //[Category("NonDeterministic")]
+    [Category("NonDeterministic")]
     public class TestDashboard
     {
         /**
@@ -34,7 +34,6 @@ namespace SEETests
             DashboardVersion version = await DashboardRetriever.Instance.GetDashboardVersionAsync();
             Assert.AreEqual(DashboardVersion.SupportedVersion.MajorVersion, version.MajorVersion);
             Assert.AreEqual(DashboardVersion.SupportedVersion.MinorVersion, version.MinorVersion);
-
         });
 
         [UnityTest]


### PR DESCRIPTION
This makes the PopupMenu scrollable. Specifically, when it reaches a certain size (40% of screen height), it won't grow larger than that, and will display a scrollbar with which the menu can be scrolled (in addition to using the mouse wheel).

### Additional changes
* Since the popup menu now has bounded height, the TreeView has been changed to allow the user to sort the entries by all existing numeric and string attributes, instead of just the pre-selected ones that were present before.
* Dashboard tests are now allowed to fail when run in context of the CI. Local test runs are not impacted by this.
* An issue has been fixed in which the TreeView did not re-open properly by pressing <kbd>Tab</kbd> if it had been closed by its close icon via the mouse.
* A bug has been fixed in which only the TreeView for one city has been opened by pressing <kbd>Tab</kbd>. Now, upon pressing <kbd>Tab</kbd>, the TreeView for every active city is added to the window as a tab.

Closes #679.