### PR TITLE
Fix problem with last used type in AddNodeAction

### DIFF
--- a/Assets/SEE/Game/SceneManipulation/GameNodeEditor.cs
+++ b/Assets/SEE/Game/SceneManipulation/GameNodeEditor.cs
@@ -2,6 +2,7 @@
 using SEE.Game.City;
 using SEE.Game.CityRendering;
 using SEE.GO;
+using SEE.Net.Actions;
 using SEE.Utils;
 using TMPro;
 using UnityEngine;
@@ -87,7 +88,8 @@ namespace SEE.Game.SceneManipulation
         {
             if (node.GameObject().ContainingCity().NodeTypes[node.Type].ShowNames
                 && node.GameObject().ContainingCity().Renderer is GraphRenderer renderer
-                && GetText(node.GameObject()) == null)
+                && GetText(node.GameObject()) == null
+                && !string.IsNullOrWhiteSpace(node.SourceName))
             {
                 renderer.AddDecorations(node.GameObject());
             }

--- a/Assets/SEE/Game/SceneManipulation/GameNodeEditor.cs
+++ b/Assets/SEE/Game/SceneManipulation/GameNodeEditor.cs
@@ -2,7 +2,6 @@
 using SEE.Game.City;
 using SEE.Game.CityRendering;
 using SEE.GO;
-using SEE.Net.Actions;
 using SEE.Utils;
 using TMPro;
 using UnityEngine;


### PR DESCRIPTION
This pull request fixes a problem where the decoration text is not displayed correctly when the last used type is applied with the NodePropertyDialog via AddNodeAction.