### PR TITLE
Fix some problems related to code windows

### DIFF
--- a/Assets/Plugins/Parser/PythonLexer.cs
+++ b/Assets/Plugins/Parser/PythonLexer.cs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:898705d02018dad132b9749f568204f4998d35418a5062236d371519aed0ea83
+size 72994

--- a/Assets/Plugins/Parser/PythonLexer.cs.meta
+++ b/Assets/Plugins/Parser/PythonLexer.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59339741917d76ea09ba805922b3031a4e9f4b7ac65e0544f69fcb1f26e3c42a
+size 243

--- a/Assets/Plugins/Parser/PythonLexer.g4
+++ b/Assets/Plugins/Parser/PythonLexer.g4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89e13bb0f9a7ffeaa9603155eac3b3f1646654753154774ad07d9e3bd90f1b65
+size 16872

--- a/Assets/Plugins/Parser/PythonLexer.g4.meta
+++ b/Assets/Plugins/Parser/PythonLexer.g4.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e580531cf1206494dc1098613551ac945c7176c540220c34bd1aa96c0ae72fb0
+size 155

--- a/Assets/Plugins/Parser/PythonLexerBase.cs
+++ b/Assets/Plugins/Parser/PythonLexerBase.cs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f039fdca3037cce5083d3b28f0965bdf4f29cc17223f928c28544e75ab26202
+size 5786

--- a/Assets/Plugins/Parser/PythonLexerBase.cs.meta
+++ b/Assets/Plugins/Parser/PythonLexerBase.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8249520a967600a24a90ce52adaccab1e313c14f0f1bdacafc9ac0b0e2c980f
+size 243

--- a/Assets/Plugins/Parser/README.md
+++ b/Assets/Plugins/Parser/README.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:659d3ad6d5705ecb3a3f1451d351588a55e80eddfa10c79f222c6e62c84af690
-size 6102
+oid sha256:f2a2d5feeaafb85ecfce40721885faff4ea730b911e3ee3b39354d5b182ccd42
+size 6330

--- a/Assets/SEE/DataModel/DG/IO/LSPImporter.cs
+++ b/Assets/SEE/DataModel/DG/IO/LSPImporter.cs
@@ -1,16 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using MoreLinq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using SEE.Tools;
 using SEE.Tools.LSP;
 using SEE.Utils;
 using SEE.Utils.Markdown;
-using UnityEngine;
 using UnityEngine.Assertions;
+using Debug = UnityEngine.Debug;
 
 namespace SEE.DataModel.DG.IO
 {
@@ -174,6 +178,25 @@ namespace SEE.DataModel.DG.IO
         private const string SelectionRangeAttribute = "SelectionRange";
 
         /// <summary>
+        /// Whether the given <paramref name="checkPath"/> applies to the given <paramref name="actualPath"/>.
+        /// </summary>
+        /// <param name="checkPath">The path to check. May be a regular expression if ending with $.</param>
+        /// <param name="actualPath">The actual path to compare against.</param>
+        /// <returns>True if the check path applies to the actual path, false otherwise.</returns>
+        private static bool PathApplies(string checkPath, string actualPath)
+        {
+            if (checkPath.EndsWith('$'))
+            {
+                // This is a regular expression.
+                return Regex.IsMatch(actualPath, checkPath);
+            }
+            else
+            {
+                return actualPath.StartsWith(checkPath);
+            }
+        }
+
+        /// <summary>
         /// Loads nodes and edges from the language server and adds them to the given <paramref name="graph"/>.
         /// </summary>
         /// <param name="graph">The graph to which the nodes and edges should be added.</param>
@@ -186,7 +209,7 @@ namespace SEE.DataModel.DG.IO
             // Query all documents whose file extension is supported by the language server.
             List<string> relevantExtensions = Handler.Server.Languages.SelectMany(x => x.FileExtensions).ToList();
             List<string> relevantDocuments = SourcePaths.SelectMany(RelevantDocumentsForPath)
-                                                        .Where(x => ExcludedPaths.All(y => !x.StartsWith(y)))
+                                                        .Where(x => ExcludedPaths.All(y => !PathApplies(y, x)))
                                                         .Distinct().ToList();
             IList<Node> originalNodes = graph.Nodes();
             nodeAtDirectory.Clear();

--- a/Assets/SEE/GraphProviders/LSPGraphProvider.cs
+++ b/Assets/SEE/GraphProviders/LSPGraphProvider.cs
@@ -60,7 +60,7 @@ namespace SEE.GraphProviders
                  InfoMessageType.Info, "@" + nameof(SourcePaths) + ".Length == 0"),
          ValidateInput(nameof(ValidSourcePaths), "The source paths must be within the project path."),
          RuntimeTab(GraphProviderFoldoutGroup)]
-        public string[] SourcePaths = Array.Empty<string>();
+        public List<string> SourcePaths = new();
 
         /// <summary>
         /// The paths within the project whose contents should be excluded from the analysis.
@@ -69,7 +69,7 @@ namespace SEE.GraphProviders
              + "Inputs ending with $ will be considered as regular expressions."),
          FolderPath(AbsolutePath = true, ParentFolder = "@" + nameof(ProjectPath) + ".Path"),
          RuntimeTab(GraphProviderFoldoutGroup)]
-        public string[] ExcludedSourcePaths = Array.Empty<string>();
+        public List<string> ExcludedSourcePaths = new();
 
         // By default, all edge types are included, except for <see cref="EdgeKind.Definition"/>
         // and <see cref="EdgeKind.Declaration"/>, since nodes would otherwise often get a self-reference.
@@ -264,14 +264,14 @@ namespace SEE.GraphProviders
             }
             changePercentage?.Invoke(0.0001f);
 
-            if (SourcePaths.Length == 0)
+            if (SourcePaths.Count == 0)
             {
-                SourcePaths = new[] { ProjectPath.Path };
+                SourcePaths = new List<string> { ProjectPath.Path };
             }
 
             try
             {
-                LSPImporter importer = new(handler, SourcePaths, ExcludedSourcePaths ?? Array.Empty<string>(),
+                LSPImporter importer = new(handler, SourcePaths, ExcludedSourcePaths ?? new(),
                                            IncludedNodeTypes, IncludedDiagnosticLevels,
                                            IncludedEdgeTypes, AvoidSelfReferences, AvoidParentReferences);
                 using (LoadingSpinner.ShowDeterminate("Creating graph using LSP...", out Action<float> updateProgress))

--- a/Assets/SEE/GraphProviders/LSPGraphProvider.cs
+++ b/Assets/SEE/GraphProviders/LSPGraphProvider.cs
@@ -54,7 +54,7 @@ namespace SEE.GraphProviders
         /// The paths within the project (recursively) containing the source code to be analyzed.
         /// </summary>
         [Tooltip("The paths within the project (recursively) containing the source code to be analyzed."),
-         FolderPath(AbsolutePath = true, ParentFolder = "@" + nameof(ProjectPath) + ".Path", RequireExistingPath = true),
+         FolderPath(AbsolutePath = true, ParentFolder = "@" + nameof(ProjectPath) + ".Path"),
          InfoBox("If no source paths are specified, all directories within the project path "
                  + "containing source code will be considered.",
                  InfoMessageType.Info, "@" + nameof(SourcePaths) + ".Length == 0"),
@@ -65,9 +65,9 @@ namespace SEE.GraphProviders
         /// <summary>
         /// The paths within the project whose contents should be excluded from the analysis.
         /// </summary>
-        [Tooltip("The paths within the project whose contents should be excluded from the analysis."),
-         FolderPath(AbsolutePath = true, ParentFolder = "@" + nameof(ProjectPath) + ".Path", RequireExistingPath = true),
-         ValidateInput(nameof(ValidSourcePaths), "The source paths must be within the project path."),
+        [Tooltip("The paths within the project whose contents should be excluded from the analysis. "
+             + "Inputs ending with $ will be considered as regular expressions."),
+         FolderPath(AbsolutePath = true, ParentFolder = "@" + nameof(ProjectPath) + ".Path"),
          RuntimeTab(GraphProviderFoldoutGroup)]
         public string[] ExcludedSourcePaths = Array.Empty<string>();
 

--- a/Assets/SEE/Scanner/Antlr/AntlrLanguage.cs
+++ b/Assets/SEE/Scanner/Antlr/AntlrLanguage.cs
@@ -61,6 +61,11 @@ namespace SEE.Scanner.Antlr
         /// </summary>
         public ISet<string> Newline { get; }
 
+        /// <summary>
+        /// Symbolic names for ignored tokens in a language.
+        /// </summary>
+        public ISet<string> Ignored { get; }
+
         #region Java Language
 
         /// <summary>
@@ -429,10 +434,11 @@ namespace SEE.Scanner.Antlr
         private AntlrLanguage(string lexerFileName, ISet<string> fileExtensions, ISet<string> keywords, ISet<string> branchKeywords,
                               ISet<string> numberLiterals, ISet<string> stringLiterals, ISet<string> punctuation,
                               ISet<string> identifiers, ISet<string> whitespace, ISet<string> newline,
-                              ISet<string> comments, int tabWidth = defaultTabWidth) : base(lexerFileName, fileExtensions, tabWidth)
+                              ISet<string> comments, ISet<string> ignored = null,
+                              int tabWidth = defaultTabWidth) : base(lexerFileName, fileExtensions, tabWidth)
         {
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
-            if (AllAntlrLanguages.Except(new []{this}).Any(x => x.LexerFileName == lexerFileName || x.FileExtensions.Overlaps(fileExtensions)))
+            if (AllAntlrLanguages.Except(new[] { this }).Any(x => x.LexerFileName == lexerFileName || x.FileExtensions.Overlaps(fileExtensions)))
             {
                 throw new ArgumentException("Lexer file name and file extensions must be unique per language!");
             }
@@ -451,6 +457,7 @@ namespace SEE.Scanner.Antlr
             Whitespace = whitespace;
             Newline = newline;
             Comments = comments;
+            Ignored = ignored ?? new HashSet<string>();
 
             return;
 
@@ -575,6 +582,10 @@ namespace SEE.Scanner.Antlr
             if (Newline.Contains(token))
             {
                 return nameof(Newline);
+            }
+            if (Ignored.Contains(token))
+            {
+                return nameof(Ignored);
             }
             return eof.Equals(token) ? nameof(eof) : null;
         }

--- a/Assets/SEE/Scanner/Antlr/AntlrLanguage.cs
+++ b/Assets/SEE/Scanner/Antlr/AntlrLanguage.cs
@@ -340,6 +340,82 @@ namespace SEE.Scanner.Antlr
 
         #endregion
 
+        #region Python Language
+
+        /// <summary>
+        /// Name of the Python antlr grammar lexer.
+        /// </summary>
+        private const string pythonFileName = "PythonLexer.g4";
+
+        /// <summary>
+        /// Set of Python file extensions.
+        /// </summary>
+        private static readonly HashSet<string> pythonExtensions = new()
+        {
+            "py", "py3", "pyi"
+        };
+
+        /// <summary>
+        /// Set of antlr type names for Python keywords excluding <see cref="pythonBranchKeywords"/>.
+        /// </summary>
+        private static readonly HashSet<string> pythonKeywords = new()
+        {
+            "DEF", "RETURN", "RAISE", "FROM", "IMPORT", "NONLOCAL", "AS", "GLOBAL", "ASSERT",
+            "IN", "NONE", "FINALLY", "WITH", "EXCEPT", "LAMBDA", "OR", "AND", "NOT", "IS",
+            "CLASS", "YIELD", "DEL", "PASS", "CONTINUE", "BREAK", "ASYNC", "AWAIT", "PRINT", "EXEC", "TRUE", "FALSE",
+        };
+
+        /// <summary>
+        /// Set of antlr type names for Python branch keywords.
+        /// </summary>
+        private static readonly HashSet<string> pythonBranchKeywords = new()
+        {
+            "FOR", "IF", "ELIF", "ELSE", "TRY", "WHILE"
+        };
+
+        /// <summary>
+        /// Set of antlr type names for Python integer and floating point literals.
+        /// </summary>
+        private static readonly HashSet<string> pythonNumbers = new()
+        {
+            "DECIMAL_INTEGER", "OCT_INTEGER", "HEX_INTEGER", "BIN_INTEGER", "IMAG_NUMBER", "FLOAT_NUMBER"
+        };
+
+        /// <summary>Set of antlr type names for Python character and string literals.</summary>
+        private static readonly HashSet<string> pythonStrings = new() { "STRING" };
+
+        /// <summary>Set of antlr type names for Python separators and operators.</summary>
+        private static readonly HashSet<string> pythonPunctuation = new()
+        {
+            "DOT", "ELLIPSIS", "REVERSE_QUOTE", "STAR", "COMMA", "COLON", "SEMI_COLON", "POWER", "ASSIGN", "OR_OP", "XOR", "AND_OP",
+            "LEFT_SHIFT", "RIGHT_SHIFT", "ADD", "MINUS", "DIV", "MOD", "IDIV", "NOT_OP", "LESS_THAN", "GREATER_THAN", "EQUALS", "GT_EQ",
+            "LT_EQ", "NOT_EQ_1", "NOT_EQ_2", "AT", "ARROW", "ADD_ASSIGN", "SUB_ASSIGN", "MULT_ASSIGN", "AT_ASSIGN", "DIV_ASSIGN", "MOD_ASSIGN",
+            "AND_ASSIGN", "OR_ASSIGN", "XOR_ASSIGN", "LEFT_SHIFT_ASSIGN", "RIGHT_SHIFT_ASSIGN", "POWER_ASSIGN", "IDIV_ASSIGN",
+            "OPEN_PAREN", "CLOSE_PAREN", "OPEN_BRACE", "CLOSE_BRACE", "OPEN_BRACKET", "CLOSE_BRACKET"
+        };
+
+        /// <summary>Set of antlr type names for Python identifiers.</summary>
+        private static readonly HashSet<string> pythonIdentifiers = new() { "NAME" };
+
+        /// <summary>
+        /// Set of antlr type names for Python whitespace.
+        /// </summary>
+        private static readonly HashSet<string> pythonWhitespace = new() { "WS" };
+
+        /// <summary>
+        /// Set of antlr type names for Python newlines.
+        /// </summary>
+        private static readonly HashSet<string> pythonNewlines = new() { "NEWLINE", "LINE_JOIN" };
+
+        /// <summary>
+        /// Set of antlr type names for Python comments.
+        /// </summary>
+        private static readonly HashSet<string> pythonComments = new() { "COMMENT" };
+
+        private static readonly HashSet<string> pythonIgnored = new() { "INDENT", "DEDENT", "LINE_BREAK" };
+
+        #endregion
+
         #region Plain Text "Language"
 
         /// <summary>
@@ -410,6 +486,12 @@ namespace SEE.Scanner.Antlr
         /// </summary>
         public static readonly AntlrLanguage Plain = new(plainFileName, plainExtensions, plainKeywords, plainBranchKeywords, plainNumbers,
                                                          plainStrings, plainPunctuation, plainIdentifiers, plainWhitespace, plainNewlines, plainComments);
+
+        /// <summary>
+        /// Token Language for Python.
+        /// </summary>
+        public static readonly AntlrLanguage Python = new(pythonFileName, pythonExtensions, pythonKeywords, pythonBranchKeywords, pythonNumbers,
+                                                          pythonStrings, pythonPunctuation, pythonIdentifiers, pythonWhitespace, pythonNewlines, pythonComments, pythonIgnored);
 
         #endregion
 
@@ -530,6 +612,7 @@ namespace SEE.Scanner.Antlr
                 javaFileName => new Java9Lexer(input),
                 cSharpFileName => new CSharpLexer(input),
                 cppFileName => new CPP14Lexer(input),
+                pythonFileName => new PythonLexer(input),
                 plainFileName => new PlainTextLexer(input),
                 _ => throw new InvalidOperationException("No lexer defined for this language yet.")
             };

--- a/Assets/SEE/Scanner/Antlr/AntlrTokenType.cs
+++ b/Assets/SEE/Scanner/Antlr/AntlrTokenType.cs
@@ -75,6 +75,11 @@ namespace SEE.Scanner.Antlr
         /// </summary>
         public static readonly AntlrTokenType Comment = new("Comments", "#6F708E"); // dark bluish gray
 
+        /// <summary>
+        /// Tokens that are not part of the language, but are still recognized by the lexer.
+        /// </summary>
+        public static readonly AntlrTokenType Ignored = new("Ignored", "#FF0000"); // red, should not be rendered
+
         #endregion
 
         private AntlrTokenType(string name, string color) : base(name, color)

--- a/Assets/SEE/Scanner/TokenType.cs
+++ b/Assets/SEE/Scanner/TokenType.cs
@@ -29,6 +29,7 @@ namespace SEE.Scanner
         /// </summary>
         public static readonly TokenType EOF = new("eof", "#000000"); // color doesn't matter
 
+
         #endregion
 
         protected TokenType(string name, string color)

--- a/Assets/SEE/Scanner/TokenType.cs
+++ b/Assets/SEE/Scanner/TokenType.cs
@@ -29,7 +29,6 @@ namespace SEE.Scanner
         /// </summary>
         public static readonly TokenType EOF = new("eof", "#000000"); // color doesn't matter
 
-
         #endregion
 
         protected TokenType(string name, string color)

--- a/Assets/SEE/UI/Window/CodeWindow/CodeWindowInput.cs
+++ b/Assets/SEE/UI/Window/CodeWindow/CodeWindowInput.cs
@@ -94,7 +94,7 @@ namespace SEE.UI.Window.CodeWindow
             // However, we need to also add "hidden" newlines contained in other tokens, e.g. block comments.
             int assumedLines = tokenList.Count(x => x.TokenType.Equals(TokenType.Newline))
                 + tokenList.Where(x => !x.TokenType.Equals(TokenType.Newline))
-                           .Aggregate(0, (_, token) => token.Text.Count(x => x == '\n'));
+                           .Aggregate(0, (i, token) => i + token.Text.Count(x => x == '\n'));
             // Needed padding is the number of lines, because the line number will be at most this long.
             neededPadding = Mathf.FloorToInt(Mathf.Log10(assumedLines)) + 1;
             text = $"<color=#CCCCCC>{string.Join("", Enumerable.Repeat(" ", neededPadding - 1))}1</color> ";
@@ -398,6 +398,7 @@ namespace SEE.UI.Window.CodeWindow
                     // Usage of LSP in code windows must be configured in the LSPHandler,
                     // the language server must support semantic tokens, and the language of the file
                     // (inferred from the file extension) must be supported by the server.
+                    lspHandler = null;
                     if (go.TryGetComponent(out lspHandler) && lspHandler.UseInCodeWindows
                         && lspHandler.ServerCapabilities.SemanticTokensProvider != null
                         && TryGetLanguageOrLog(lspHandler, out LSPLanguage language))
@@ -408,7 +409,6 @@ namespace SEE.UI.Window.CodeWindow
                     }
                     else
                     {
-                        lspHandler = null;
                         tokens = await AntlrToken.FromFileAsync(filename);
                     }
                 }

--- a/Assets/SEE/UI/Window/CodeWindow/CodeWindowInput.cs
+++ b/Assets/SEE/UI/Window/CodeWindow/CodeWindowInput.cs
@@ -83,7 +83,7 @@ namespace SEE.UI.Window.CodeWindow
             }
 
             // Avoid multiple enumeration in case iteration over the data source is expensive.
-            tokenList = tokens.ToList();
+            tokenList = tokens.Where(x => x.TokenType != AntlrTokenType.Ignored).ToList();
             if (!tokenList.Any())
             {
                 text = "<i>This file is empty.</i>";

--- a/Axivion/axivion-jenkins.bat
+++ b/Axivion/axivion-jenkins.bat
@@ -107,7 +107,7 @@ if "%AXIVION_DASHBOARD_URL%"=="" (
 )
 
 if "%UNITY%"=="" (
-  set "UNITY=C:\Program Files\Unity\Hub\Editor\2022.3.52f1"
+  set "UNITY=C:\Program Files\Unity\Hub\Editor\2022.3.53f1"
 )
 
 if not exist "%UNITY%" (

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.52f1
-m_EditorVersionWithRevision: 2022.3.52f1 (1120fcb54228)
+m_EditorVersion: 2022.3.53f1
+m_EditorVersionWithRevision: 2022.3.53f1 (df4e529d20d3)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/uni-bremen-agst/SEE/actions/workflows/main.yml/badge.svg)](https://github.com/uni-bremen-agst/SEE/actions/workflows/main.yml)
 
 SEE visualizes hierarchical dependency graphs of software in 3D/VR based on the city metaphor.
-The underlying game engine is Unity 3D (version 2022.3.52f1).
+The underlying game engine is Unity 3D (version 2022.3.53f1).
 
 ![Screenshot of SEE](Screenshot.png)
 


### PR DESCRIPTION
This PR fixes some small problems that are in some way related to code windows, and also adds Python as a supported language for our Antlr lexer.

## Details
- A Python lexer has been added. This means that Python code can now be syntax highlighted in code windows even when not using a Python language server.
- A new Antlr token type `Ignored` has been added that will not be rendered at all—this is useful for lexers which create artificial tokens that SEE otherwise could not handle before.
- Documentation for how to generate Antlr lexers has been updated, as it previously referred to an older structure of SEE that no longer exists.
- Line numbers were previously incorrectly counted for some edge cases, leading to issues (e.g., Dashboard or LSP diagnostics) getting lost.
- The excluded source paths for the LSP graph provider can now be specified as a regular expression when ending it with a `$` (e.g., `.*test[^/]*.rs$` would exclude all Rust files that have `test` in their name).
- An issue in the LSP graph provider where arrays for source paths and excluded source paths pointed to the same instance has been fixed.
- Unity has been updated to 2022.3.53f1.