### PR TITLE
Some bug fixes for WSRE

### DIFF
--- a/Assets/SEE/Controls/Actions/ContextMenuAction.cs
+++ b/Assets/SEE/Controls/Actions/ContextMenuAction.cs
@@ -422,7 +422,7 @@ namespace SEE.Controls.Actions
             }
 
             entries.Add(new PopupMenuAction(graphElement is Node no && no.IsArchitectureOrImplementationRoot() ?
-                "Clear" : (graphElement as Node).IsRoot() ? "Delete City" : "Delete", () => DeleteElement().Forget(), Icons.Trash, Priority: 0));
+                "Clear" : graphElement is Node nodeElement && nodeElement.IsRoot() ? "Delete City" : "Delete", () => DeleteElement().Forget(), Icons.Trash, Priority: 0));
 
             if (appendActions == null && graphElement is Node n && n.IsArchitectureOrImplementationRoot())
             {

--- a/Assets/SEE/Game/CityRendering/GraphRenderer.cs
+++ b/Assets/SEE/Game/CityRendering/GraphRenderer.cs
@@ -308,8 +308,8 @@ namespace SEE.Game.CityRendering
 
             // 1) Calculate the layout.
             Performance p = Performance.Begin($"Node layout {Settings.NodeLayoutSettings.Kind} for {gameNodes.Count} nodes");
-            // the layout to be applied
-            NodeLayout nodeLayout = GetLayout();
+            /// The layout to be applied. If <see cref="doNotAddUniqueRoot"/> is true, use <see cref="NodeLayoutKind.Treemap"/> as the layout.
+            NodeLayout nodeLayout = !doNotAddUniqueRoot? GetLayout() : GetLayout(NodeLayoutKind.Treemap);
             // Equivalent to gameNodes but as an ICollection<ILayoutNode> instead of ICollection<GameNode>
             // (GameNode implements ILayoutNode).
             ICollection<ILayoutNode> layoutNodes = gameNodes.Values.Cast<ILayoutNode>().ToList();

--- a/Assets/SEE/Net/Actions/RuntimeConfig/UpdateCityMethodNetAction.cs
+++ b/Assets/SEE/Net/Actions/RuntimeConfig/UpdateCityMethodNetAction.cs
@@ -3,17 +3,17 @@ using SEE.UI.RuntimeConfigMenu;
 namespace SEE.Net.Actions.RuntimeConfig
 {
     /// <summary>
-    /// Network action when a city method was called.
+    /// Network action when a city method was called to synchronize a code city's state.
     /// </summary>
     public class UpdateCityMethodNetAction : UpdateCityNetAction
     {
         /// <summary>
-        /// The method name
+        /// The method name to be called.
         /// </summary>
         public string MethodName;
 
         /// <summary>
-        /// Triggers 'SyncMethod' on <see cref="RuntimeTabMenu"/>.
+        /// Triggers <see cref="RuntimeTabMenu.SyncMethod"/>.
         /// </summary>
         public override void ExecuteOnClient()
         {

--- a/Assets/SEE/UI/RuntimeConfigMenu/RuntimeTabMenu.cs
+++ b/Assets/SEE/UI/RuntimeConfigMenu/RuntimeTabMenu.cs
@@ -867,7 +867,7 @@ namespace SEE.UI.RuntimeConfigMenu
                         ValueType = valueType.FullName
                     };
                     netAction.Execute();
-                    ReDraw();
+                    ImmediateRedraw();
                 }
             }
         }
@@ -1701,8 +1701,16 @@ namespace SEE.UI.RuntimeConfigMenu
                 return;
             }
 
-            TriggerImmediateRedraw();
+            ImmediateRedraw();
+        }
 
+
+        /// <summary>
+        /// Triggers the immediate redrawn of the city and calls the network behaviour.
+        /// </summary>
+        private void ImmediateRedraw()
+        {
+            TriggerImmediateRedraw();
             UpdateCityMethodNetAction netAction = new()
             {
                 CityIndex = CityIndex,
@@ -1717,41 +1725,6 @@ namespace SEE.UI.RuntimeConfigMenu
         private void TriggerImmediateRedraw()
         {
             // does nothing if no graph is loaded
-            if (city.LoadedGraph == null)
-            {
-                return;
-            }
-
-            city.Invoke(nameof(SEECity.LoadDataAsync), 0);
-            StartCoroutine(DrawNextFrame());
-
-            IEnumerator DrawNextFrame()
-            {
-                yield return 0;
-                city.Invoke(nameof(SEECity.DrawGraph), 0);
-            }
-        }
-
-        /// <summary>
-        /// Redraws the city.
-        /// </summary>
-        private void ReDraw()
-        {
-            TriggerReDraw();
-            UpdateCityMethodNetAction netAction = new()
-            {
-                CityIndex = CityIndex,
-                MethodName = nameof(TriggerReDraw)
-            };
-            netAction.Execute();
-        }
-
-        /// <summary>
-        /// Immediately redraws the city using the <see cref="SEECity.ReDrawGraph"/>
-        /// function.
-        /// </summary>
-        private void TriggerReDraw()
-        {
             if (city.LoadedGraph == null)
             {
                 return;

--- a/Assets/SEE/UI/RuntimeConfigMenu/RuntimeTabMenu.cs
+++ b/Assets/SEE/UI/RuntimeConfigMenu/RuntimeTabMenu.cs
@@ -1704,7 +1704,6 @@ namespace SEE.UI.RuntimeConfigMenu
             ImmediateRedraw();
         }
 
-
         /// <summary>
         /// Triggers the immediate redrawn of the city and calls the network behaviour.
         /// </summary>

--- a/Assets/SEE/UI/RuntimeConfigMenu/RuntimeTabMenu.cs
+++ b/Assets/SEE/UI/RuntimeConfigMenu/RuntimeTabMenu.cs
@@ -1705,7 +1705,8 @@ namespace SEE.UI.RuntimeConfigMenu
         }
 
         /// <summary>
-        /// Triggers the immediate redrawn of the city and calls the network behaviour.
+        /// Triggers the immediate redraw <see cref="TriggerImmediateRedraw"/> of the city
+        /// locally and on all connected clients (the latter via <see cref="UpdateCityMethodNetAction"/>).
         /// </summary>
         private void ImmediateRedraw()
         {

--- a/Assets/SEE/UI/Window/TreeWindow/DesktopTreeWindow.cs
+++ b/Assets/SEE/UI/Window/TreeWindow/DesktopTreeWindow.cs
@@ -462,16 +462,6 @@ namespace SEE.UI.Window.TreeWindow
                             Rebuild();
                         }, Icons.Hide)
                     };
-                    /*
-                     * FIXME(#834). Remove this code or re-activate if still required.
-                    if (representedGraphElement is Node node && node.IsRoot())
-                    {
-                        appends.Add(new("Delete City", () =>
-                        {
-                            WindowSpace winSpace = WindowSpaceManager.ManagerInstance[WindowSpaceManager.LocalPlayer];
-                            ContextMenuAction.DeleteCityAsync(node, () => winSpace.CloseWindow(this)).Forget();
-                        }, Icons.Trash));
-                    }*/
 
                     IEnumerable<PopupMenuEntry> actions = ContextMenuAction
                         .GetOptionsForTreeView(contextMenu.ContextMenu, position, representedGraphElement, representedGameObject, appends);


### PR DESCRIPTION
This pull request includes serveral bug fixes that arose during the preparation for the WSRE presentation.
For example, it resolves an issue where it was not possible to load a part of the ReflexionCity due to an incorrect layout being selected.
Additionally, it fixes a redraw bug in the RuntimeConfigMenu when using a initial ReflexionCity.
It also fixes issue #834 .