### PR TITLE
836 improve desktop player movement roll camera and smooth initial movement

### DIFF
--- a/Assets/Plugins/Runtime Transform Gizmos.meta
+++ b/Assets/Plugins/Runtime Transform Gizmos.meta
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fafb52522a30dd3e752ff97d1ac05b78e2e03e369eec568e734c3750d113f10
-size 172

--- a/Assets/SEE/Controls/DesktopPlayerMovement.cs
+++ b/Assets/SEE/Controls/DesktopPlayerMovement.cs
@@ -8,18 +8,45 @@ namespace SEE.Controls
     /// </summary>
     public class DesktopPlayerMovement : PlayerMovement
     {
+        /// <summary>
+        /// The time in seconds it takes to reach the speed defined in <see cref="Speed"/>
+        /// after the player has initiated a movement.
+        /// </summary>
+        private const float timeToReachSpeed = 0.5f;
+
+        /// <summary>
+        /// The minimal speed factor when the player has just started to move. The initial
+        /// speed when the user initiated a movement will be
+        /// <see cref="Speed"/> * <see cref="minimalInitialSpeedFactor"/>.
+        /// </summary>
+        private const float minimalInitialSpeedFactor = 0.1f;
+
+        /// <summary>
+        /// The speed of the player movement. This is the distance in Unity units per second.
+        /// </summary>
+        /// <remarks>This actual speed depends on the point in time where the player
+        /// has initiated the movement. We will start slower and then gradually increase
+        /// the speed until <see cref="Speed"/> has been reached. This phase takes
+        /// <see cref="timeToReachSpeed"/> seconds.</remarks>
         [Tooltip("Speed of movements")]
         public float Speed = 2f;
+
+        /// <summary>
+        /// The time (in seconds) past since the player has initiated a movement.
+        /// </summary>
+        private float movingTime = 0f;
+
+        /// <summary>
+        /// The factor by which the speed is multiplied when the shift key is pressed.
+        /// </summary>
         [Tooltip("Boost factor of speed, applied when shift is pressed.")]
         public float BoostFactor = 2f;
 
+        /// <summary>
+        /// The state of the camera.
+        /// </summary>
         private struct CameraState
         {
-            /// <summary>
-            ///  The distance to the <see cref="FocusedObject"/> (the code city the player
-            ///  is conntected to). This attribute is considered only if <see cref="FreeMode"/> is false.
-            /// </summary>
-            internal float DistanceToFocusedObject;
             /// <summary>
             /// Rotation in Euler degrees around the y-axis (yaw).
             /// </summary>
@@ -33,8 +60,16 @@ namespace SEE.Controls
             /// rotating around the <see cref="FocusedObject"/> (the code city the player is conntected to).
             /// </summary>
             internal bool FreeMode;
+            /// <summary>
+            ///  The distance to the <see cref="FocusedObject"/> (the code city the player
+            ///  is conntected to). This attribute is considered only if <see cref="FreeMode"/> is false.
+            /// </summary>
+            internal float DistanceToFocusedObject;
         }
 
+        /// <summary>
+        /// The current state of the camera.
+        /// </summary>
         private CameraState cameraState;
 
         /// <summary>
@@ -43,9 +78,15 @@ namespace SEE.Controls
         /// </summary>
         private CharacterController controller;
 
+        /// <summary>
+        /// The code city which the player is focusing on if not in free mode.
+        /// </summary>
         [Tooltip("The code city which the player is focusing on.")]
         public GO.Plane FocusedObject;
 
+        /// <summary>
+        /// Sets up the <see cref="CharacterController"/> and the <see cref="cameraState"/>.
+        /// </summary>
         private void Start()
         {
             controller = gameObject.MustGetComponent<CharacterController>();
@@ -80,6 +121,9 @@ namespace SEE.Controls
             lastAxis = new Vector2(Input.mousePosition.x, Input.mousePosition.y);
         }
 
+        /// <summary>
+        /// Reacts to the user input.
+        /// </summary>
         private void Update()
         {
             if (FocusedObject != null && SEEInput.ToggleCameraLock())
@@ -96,24 +140,28 @@ namespace SEE.Controls
                 }
             }
 
-            float speed = Speed * Time.deltaTime;
-            if (SEEInput.BoostCameraSpeed())
-            {
-                speed *= BoostFactor;
-            }
-
             if (!cameraState.FreeMode)
             {
-                float d = 0.0f;
+                float distance = GetDistance();
+                float step = 0.0f;
                 if (SEEInput.MoveForward())
                 {
-                    d += speed;
+                    step += distance;
                 }
                 if (SEEInput.MoveBackward())
                 {
-                    d -= speed;
+                    step -= distance;
                 }
-                cameraState.DistanceToFocusedObject -= d;
+                if (step == 0)
+                {
+                    // No movement has been initiated, so we reset the moving time.
+                    movingTime = 0f;
+                }
+                else
+                {
+                    movingTime += Time.deltaTime;
+                }
+                cameraState.DistanceToFocusedObject -= step;
 
                 HandleRotation();
                 transform.SetPositionAndRotation(FocusedObject.CenterTop, Quaternion.Euler(cameraState.Pitch, cameraState.Yaw, 0.0f));
@@ -121,35 +169,46 @@ namespace SEE.Controls
             }
             else // cameraState.freeMode == true
             {
-                Vector3 velocity = Vector3.zero;
+                // The directed distance the player should be moved in this frame.
+                Vector3 step = Vector3.zero;
+                // Determine the direction of the movement.
                 if (SEEInput.MoveForward())
                 {
-                    velocity += transform.forward;
+                    step += transform.forward;
                 }
                 if (SEEInput.MoveBackward())
                 {
-                    velocity -= transform.forward;
+                    step -= transform.forward;
                 }
                 if (SEEInput.MoveRight())
                 {
-                    velocity += transform.right;
+                    step += transform.right;
                 }
                 if (SEEInput.MoveLeft())
                 {
-                    velocity -= transform.right;
+                    step -= transform.right;
                 }
                 if (SEEInput.MoveUp())
                 {
-                    velocity += Vector3.up;
+                    step += Vector3.up;
                 }
                 if (SEEInput.MoveDown())
                 {
-                    velocity += Vector3.down;
+                    step += Vector3.down;
                 }
-                velocity.Normalize();
-                velocity *= speed;
+                step.Normalize();
+                if (step == Vector3.zero)
+                {
+                    // No movement has been initiated, so we reset the moving time.
+                    movingTime = 0f;
+                }
+                else
+                {
+                    movingTime += Time.deltaTime;
+                }
+                step *= GetDistance();
                 // The following two lines may look strange, yet both are actually needed.
-                controller.Move(velocity); // this is the actual movement
+                controller.Move(step); // this is the actual movement
                 controller.Move(Vector3.zero); // this prevents the player from sliding without input
 
                 HandleRotation();
@@ -157,6 +216,20 @@ namespace SEE.Controls
                 transform.rotation = Quaternion.Euler(0.0f, cameraState.Yaw, 0.0f);
                 // Cameras Pitch and Yaw
                 Camera.main.transform.rotation = Quaternion.Euler(cameraState.Pitch, cameraState.Yaw, 0.0f);
+            }
+
+            // The distance the player should be moved in this frame (in any direction) taking
+            // into account the movingTime and potentially the boost factor.
+            float GetDistance()
+            {
+                // Movement should be started at minimalInitialSpeedFactor * Speed and then
+                // linearly increased to Speed.
+                float distance = Mathf.Lerp(minimalInitialSpeedFactor * Speed, Speed, movingTime / timeToReachSpeed) * Time.deltaTime;
+                if (SEEInput.BoostCameraSpeed())
+                {
+                    distance *= BoostFactor;
+                }
+                return distance;
             }
         }
 

--- a/Assets/SEE/Controls/DesktopPlayerMovement.cs
+++ b/Assets/SEE/Controls/DesktopPlayerMovement.cs
@@ -224,7 +224,7 @@ namespace SEE.Controls
             {
                 // Movement should be started at minimalInitialSpeedFactor * Speed and then
                 // linearly increased to Speed.
-                float distance = Mathf.Lerp(minimalInitialSpeedFactor * Speed, Speed, movingTime / timeToReachSpeed) * Time.deltaTime;
+                float distance = Mathf.Lerp(minimalInitialSpeedFactor * Speed, Speed, Mathf.Min(movingTime / timeToReachSpeed, 1f)) * Time.deltaTime;
                 if (SEEInput.BoostCameraSpeed())
                 {
                     distance *= BoostFactor;

--- a/Assets/SEE/Controls/DesktopPlayerMovement.cs
+++ b/Assets/SEE/Controls/DesktopPlayerMovement.cs
@@ -24,7 +24,7 @@ namespace SEE.Controls
         /// <summary>
         /// The speed of the player movement. This is the distance in Unity units per second.
         /// </summary>
-        /// <remarks>This actual speed depends on the point in time where the player
+        /// <remarks>The actual speed depends on the point in time where the player
         /// has initiated the movement. We will start slower and then gradually increase
         /// the speed until <see cref="Speed"/> has been reached. This phase takes
         /// <see cref="timeToReachSpeed"/> seconds.</remarks>


### PR DESCRIPTION
The initial movement is now smoother. It starts at 10% of the target speed and then linearly increases to the full speed in 0.5 seconds.

The rolling of the camera was already implemented. In a follow-up issue we could add a bending animation to the avatar when the camera is rolled.