### PR TITLE
fix: false rendering of author edges in on-hover mode

### DIFF
--- a/Assets/SEE/Controls/ShowAuthorEdges.cs
+++ b/Assets/SEE/Controls/ShowAuthorEdges.cs
@@ -31,7 +31,7 @@ namespace SEE.Controls.Actions
         }
 
         /// <summary>
-        /// Sets <see cref="Interactable"/> and subscribes to hover events.
+        /// Subscribes to hover events of the game object.
         /// </summary>
         void OnEnable()
         {

--- a/Assets/SEE/Controls/ShowAuthorEdges.cs
+++ b/Assets/SEE/Controls/ShowAuthorEdges.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
-using SEE.Game;
 using SEE.Game.City;
 using SEE.GameObjects;
 using SEE.GO;
@@ -76,18 +75,20 @@ namespace SEE.Controls.Actions
                     return;
                 }
             }
-
-            foreach (GameObject edge in authorRef.Edges.Select(x => x.Item1))
+            else
             {
-                edge.EdgeOperator()?.ShowOrHide(show, animationKind);
-            }
-            if (show)
-            {
-                await UniTask.Delay(ShowEdges.TransitiveDelay, cancellationToken: token);
-            }
-            if (token.IsCancellationRequested)
-            {
-                return;
+                foreach (GameObject edge in authorRef.Edges.Select(x => x.Item1))
+                {
+                    edge.EdgeOperator()?.ShowOrHide(show, animationKind);
+                }
+                if (show)
+                {
+                    await UniTask.Delay(ShowEdges.TransitiveDelay, cancellationToken: token);
+                }
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
             }
         }
 
@@ -114,9 +115,13 @@ namespace SEE.Controls.Actions
 
             foreach (GameObject edge in sphere.Edges.Select(x => x.Item1))
             {
+                bool hasAuthorEdge = edge.TryGetComponent(out AuthorEdge authorEdge);
                 // Only show edges in which the author threshold is not reached.
-                if (edge.TryGetComponent(out AuthorEdge authorEdge)
-                    && authorEdge.targetNode.Edges.Count < branchCity.AuthorThreshold)
+                bool belowThreshold = hasAuthorEdge && authorEdge.targetNode.Edges.Count < branchCity.AuthorThreshold;
+                // Or if ShowOnHover was set as strategy.
+                bool showOnHover = branchCity.ShowAuthorEdgesStrategy == ShowAuthorEdgeStrategy.ShowOnHover;
+
+                if (belowThreshold || showOnHover)
                 {
                     edge.EdgeOperator()?.ShowOrHide(show, animationKind);
                 }

--- a/Assets/SEE/Game/City/BranchCity.cs
+++ b/Assets/SEE/Game/City/BranchCity.cs
@@ -31,7 +31,8 @@ namespace SEE.Game.City
         /// See <see cref="ShowAuthorEdgeStrategy"/> for more details what each options should do.
         /// </summary>
         [TabGroup(EdgeFoldoutGroup),
-         RuntimeTab(EdgeFoldoutGroup)]
+         RuntimeTab(EdgeFoldoutGroup), InfoBox("An edge animation kind must be set to use this feature.",
+             InfoMessageType.Error, nameof(ShowWarningBoxOfMissingAnimationKind)),]
         public ShowAuthorEdgeStrategy ShowAuthorEdgesStrategy =
                 ShowAuthorEdgeStrategy.ShowOnHoverOrWithMultipleAuthors;
 
@@ -50,6 +51,13 @@ namespace SEE.Game.City
          TabGroup(EdgeFoldoutGroup),
          RuntimeTab(EdgeFoldoutGroup)]
         public int AuthorThreshold = 2;
+
+        /// <summary>
+        /// Returns true if the user should be warned about a missing animation kind.
+        /// </summary>
+        private bool ShowWarningBoxOfMissingAnimationKind =>
+            ShowAuthorEdgesStrategy != ShowAuthorEdgeStrategy.ShowAlways &&
+            EdgeLayoutSettings.AnimationKind == EdgeAnimationKind.None;
 
         /// <summary>
         /// Resets everything that is specific to a given graph. Here in addition to

--- a/Assets/SEE/Game/CityRendering/AuthorSphereRenderer.cs
+++ b/Assets/SEE/Game/CityRendering/AuthorSphereRenderer.cs
@@ -11,6 +11,7 @@ using SEE.Utils;
 using TinySpline;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace SEE.Game.CityRendering
 {
@@ -61,6 +62,8 @@ namespace SEE.Game.CityRendering
         private void RenderEdgesForSpheres(IDictionary<Node, GameObject> nodeMap,
             IEnumerable<GameObject> spheresObjects, GameObject parent)
         {
+
+
             IEnumerable<Node> nodesWithChurn = nodeMap.Keys
                 .Where(x => x.IntAttributes.ContainsKey(DataModel.DG.VCS.Churn));
 
@@ -138,6 +141,8 @@ namespace SEE.Game.CityRendering
                         switch (branchCity.ShowAuthorEdgesStrategy)
                         {
                             case ShowAuthorEdgeStrategy.ShowOnHoverOrWithMultipleAuthors:
+                                Assert.AreNotEqual(Settings.EdgeLayoutSettings.AnimationKind, EdgeAnimationKind.None);
+
                                 gameEdge.EdgeOperator().Hide(Settings.EdgeLayoutSettings.AnimationKind, 0f);
 
                                 if (authorRef.AuthorSpheres.Count >= branchCity.AuthorThreshold)
@@ -150,6 +155,8 @@ namespace SEE.Game.CityRendering
                                 }
                                 break;
                             case ShowAuthorEdgeStrategy.ShowOnHover:
+                                Assert.AreNotEqual(Settings.EdgeLayoutSettings.AnimationKind, EdgeAnimationKind.None);
+
                                 gameEdge.EdgeOperator().Hide(Settings.EdgeLayoutSettings.AnimationKind, 0f);
                                 break;
                             case ShowAuthorEdgeStrategy.ShowAlways:

--- a/Assets/SEE/Game/CityRendering/AuthorSphereRenderer.cs
+++ b/Assets/SEE/Game/CityRendering/AuthorSphereRenderer.cs
@@ -62,8 +62,6 @@ namespace SEE.Game.CityRendering
         private void RenderEdgesForSpheres(IDictionary<Node, GameObject> nodeMap,
             IEnumerable<GameObject> spheresObjects, GameObject parent)
         {
-
-
             IEnumerable<Node> nodesWithChurn = nodeMap.Keys
                 .Where(x => x.IntAttributes.ContainsKey(DataModel.DG.VCS.Churn));
 


### PR DESCRIPTION
Supplement to #859.

Fixes edge rendering in OnHover mode and ShowOnHoverOrWithMultipleAuthors mode.