### PR TITLE
Fix PropertyWindow nested grouping conflicts and use unique group IDs

### DIFF
--- a/Assets/SEE/UI/Window/PropertyWindow/PropertyWindow.cs
+++ b/Assets/SEE/UI/Window/PropertyWindow/PropertyWindow.cs
@@ -415,7 +415,6 @@ namespace SEE.UI.Window.PropertyWindow
                     }
                     return;
                 }
-
                 else
                 {
                     // We are in the middle of the path. -> We need a folder (Dictionary).


### PR DESCRIPTION
Prevent InvalidCastException when grouping dotted attribute keys (e.g. A.B and A.B.C) by converting leaf entries into nested dictionaries and preserving the previous leaf value under _value.

Handle the reverse insertion order as well: if a container already exists for a key and a leaf value is added later, store that leaf under _value instead of overwriting the subtree.

Generate group identifiers from the full attribute path (parent.child…) to avoid name collisions between groups with the same display label, while still showing only the short label in the UI.

Add a backward-compatible DisplayGroup overload and update groupHolder documentation accordingly.