### PR TITLE
965 andcombinedoperationcallback does not chain callbacks

### DIFF
--- a/Assets/SEE/Game/CityRendering/LayoutGraphNode.cs
+++ b/Assets/SEE/Game/CityRendering/LayoutGraphNode.cs
@@ -1,5 +1,4 @@
 ﻿using SEE.DataModel.DG;
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -96,7 +95,7 @@ namespace SEE.Game.CityRendering
         /// <remarks>Intended for debugging.</remarks>
         internal static void Dump(ICollection<LayoutGraphNode> layoutNodes)
         {
-            foreach(LayoutGraphNode node in layoutNodes)
+            foreach (LayoutGraphNode node in layoutNodes)
             {
                 Debug.Log(node.ToString() + '\n');
             }

--- a/Assets/SEE/Game/CityRendering/TransitionRenderer.cs
+++ b/Assets/SEE/Game/CityRendering/TransitionRenderer.cs
@@ -729,7 +729,7 @@ namespace SEE.Game.CityRendering
                 return;
             }
 
-            // Partition all at the same hierarchy level.
+            // Partition all nodes at the same hierarchy level.
             UnionFind<Node, int> unionFind = new(movedNodes, n => n.Level);
             unionFind.PartitionByValue();
 
@@ -826,6 +826,7 @@ namespace SEE.Game.CityRendering
                             // Move the node to its new position. The edge layout will be updated below.
                             IOperationCallback<Action> animation = go.NodeOperator()
                               .ResizeTo(ToLocalScale(go, layoutNode), layoutNode.CenterPosition, updateEdges: false);
+
                             animation.OnKill(() => OnDone(go));
                             animation.OnComplete(() => OnDone(go));
                         }
@@ -982,7 +983,7 @@ namespace SEE.Game.CityRendering
 
         /// <summary>
         /// Returns the target local-space scale for <paramref name="gameNode"/> according
-        /// to the <paramref name="layoutNode"/>. If <paramref name="gameNode"/> has not
+        /// to the <paramref name="layoutNode"/>. If <paramref name="gameNode"/> has no
         /// parent yet, it is just the absolute scale of the layout node. Otherwise
         /// the absolute scale of the layout node is transformed into the local space
         /// relative to the parent of <paramref name="gameNode"/>.

--- a/Assets/SEE/Game/Operator/AndCombinedOperationCallback.cs
+++ b/Assets/SEE/Game/Operator/AndCombinedOperationCallback.cs
@@ -103,13 +103,13 @@ namespace SEE.Game.Operator
         /// <exception cref="IndexOutOfRangeException">When <paramref name="index"/> is not in [0;6].</exception>
         private void HandleSingleCallback(IOperationCallback<C> callback, int index)
         {
-            if ((callbackCounter[callback] & (1 << index)) == 1)
+            if (IsBitSet(callbackCounter[callback], index))
             {
                 // Callback already triggered.
                 return;
             }
             callbackCounter[callback] |= 1 << index;
-            if (callbackCounter.All(x => (x.Value & (1 << index)) == 1))
+            if (callbackCounter.All(x => IsBitSet(x.Value, index)))
             {
                 // All callbacks have been triggered, so we trigger the actual user-defined callback.
                 switch (index)
@@ -132,6 +132,15 @@ namespace SEE.Game.Operator
                 }
             }
         }
+
+        /// <summary>
+        /// True if the <paramref name="bit"/> is set in <paramref name="value"/>, that
+        /// is, has value 1.
+        /// </summary>
+        /// <param name="value">The value interpreted as bit sequence to be checked.</param>
+        /// <param name="bit">The position of the bit in <paramref name="value"/> to be tested.</param>
+        /// <returns>True if the <paramref name="bit"/> is set in <paramref name="value"/>.</returns>
+        private static bool IsBitSet(int value, int bit) => (value & (1 << bit)) != 0;
 
         public IOperationCallback<Action> OnComplete(Action callback)
         {

--- a/Assets/SEE/Game/Operator/AndCombinedOperationCallback.cs
+++ b/Assets/SEE/Game/Operator/AndCombinedOperationCallback.cs
@@ -135,7 +135,11 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<Action> OnComplete(Action callback)
         {
-            onComplete = callback;
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+            onComplete = onComplete == null ? callback : (Action)Delegate.Combine(onComplete, callback);
             foreach (IOperationCallback<C> operationCallback in callbacks)
             {
                 operationCallback.OnComplete(callbackConverter(() => HandleSingleCallback(operationCallback, 0)));
@@ -145,7 +149,11 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<Action> OnKill(Action callback)
         {
-            onKill = callback;
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+            onKill = onKill == null ? callback : (Action)Delegate.Combine(onKill, callback);
             foreach (IOperationCallback<C> operationCallback in callbacks)
             {
                 operationCallback.OnKill(callbackConverter(() => HandleSingleCallback(operationCallback, 1)));
@@ -155,7 +163,11 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<Action> OnPlay(Action callback)
         {
-            onPlay = callback;
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+            onPlay = onPlay == null ? callback : (Action)Delegate.Combine(onPlay, callback);
             foreach (IOperationCallback<C> operationCallback in callbacks)
             {
                 operationCallback.OnPlay(callbackConverter(() => HandleSingleCallback(operationCallback, 2)));
@@ -165,7 +177,11 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<Action> OnPause(Action callback)
         {
-            onPause = callback;
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+            onPause = onPause == null ? callback : (Action)Delegate.Combine(onPause, callback);
             foreach (IOperationCallback<C> operationCallback in callbacks)
             {
                 operationCallback.OnPause(callbackConverter(() => HandleSingleCallback(operationCallback, 3)));
@@ -175,7 +191,11 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<Action> OnRewind(Action callback)
         {
-            onRewind = callback;
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+            onRewind = onRewind == null ? callback : (Action)Delegate.Combine(onRewind, callback);
             foreach (IOperationCallback<C> operationCallback in callbacks)
             {
                 operationCallback.OnRewind(callbackConverter(() => HandleSingleCallback(operationCallback, 4)));
@@ -185,7 +205,11 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<Action> OnStart(Action callback)
         {
-            onStart = callback;
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+            onStart = onStart == null ? callback : (Action)Delegate.Combine(onStart, callback);
             foreach (IOperationCallback<C> operationCallback in callbacks)
             {
                 operationCallback.OnStart(callbackConverter(() => HandleSingleCallback(operationCallback, 5)));
@@ -195,7 +219,11 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<Action> OnUpdate(Action callback)
         {
-            onUpdate = callback;
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+            onUpdate = onUpdate == null ? callback : (Action)Delegate.Combine(onUpdate, callback);
             foreach (IOperationCallback<C> operationCallback in callbacks)
             {
                 operationCallback.OnUpdate(callbackConverter(() => HandleSingleCallback(operationCallback, 6)));

--- a/Assets/SEE/Game/Operator/DummyOperationCallback.cs
+++ b/Assets/SEE/Game/Operator/DummyOperationCallback.cs
@@ -18,6 +18,10 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<T> OnComplete(T callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // Happens instantly.
             callback.DynamicInvoke();
             return this;
@@ -25,6 +29,10 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<T> OnKill(T callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // Happens instantly.
             callback.DynamicInvoke();
             return this;
@@ -32,6 +40,10 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<T> OnPlay(T callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // Happens instantly.
             callback.DynamicInvoke();
             return this;
@@ -39,18 +51,30 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<T> OnPause(T callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // Nothing to be done.
             return this;
         }
 
         public IOperationCallback<T> OnRewind(T callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // Nothing to be done.
             return this;
         }
 
         public IOperationCallback<T> OnStart(T callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // Happens instantly.
             callback.DynamicInvoke();
             return this;
@@ -58,6 +82,10 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<T> OnUpdate(T callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // Nothing to be done.
             return this;
         }

--- a/Assets/SEE/Game/Operator/EdgeOperator.cs
+++ b/Assets/SEE/Game/Operator/EdgeOperator.cs
@@ -46,20 +46,11 @@ namespace SEE.Game.Operator
         /// <returns>An operation callback for the requested animation.</returns>
         public IOperationCallback<TweenCallback> MorphTo(BSpline target, float factor = 1)
         {
-            // TODO(#929): The comment says a later OnKill registration will overwrite this one,
-            // but IOperationCallback explicitly promises callbacks won't override, and
-            // TweenOperationCallback.OnKill uses Delegate.Combine to append callbacks.
-            // This note is misleading; consider removing it or clarifying that this
-            // limitation applies to raw DOTween Tween.OnKill usage (not the project's
-            // IOperationCallback wrapper).
             IOperationCallback<TweenCallback> result = morphism.AnimateTo((target, null), ToDuration(factor));
             // Note: Whenever OnComplete is called, OnKill is called immediately afterward.
             // On the other hand, OnComplete will be called only when the tween completed
             // successfully, while OnKill will also be called when the tween is killed or
             // the tween's object is destroyed. Hence, it is sufficient to await OnKill.
-            // IMPORTANT NOTE: If we register on OnKill here, a later register on OnKill
-            // will be overwrite this registration here. There can be only at most one
-            // registration on OnKill at a time.
             result.OnKill(AdjustCollider);
             return result;
 

--- a/Assets/SEE/Game/Operator/IOperationCallback.cs
+++ b/Assets/SEE/Game/Operator/IOperationCallback.cs
@@ -14,12 +14,14 @@ namespace SEE.Game.Operator
         /// Sets a callback that will be fired the moment the animator reaches completion, all loops included.
         /// </summary>
         /// <returns>Returns a reference to this object for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="callback"/> is null.</exception>
         IOperationCallback<T> OnComplete(T callback);
 
         /// <summary>
         /// Sets a callback that will be fired the moment the animator is killed.
         /// </summary>
         /// <returns>Returns a reference to this object for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="callback"/> is null.</exception>
         IOperationCallback<T> OnKill(T callback);
 
         /// <summary>
@@ -27,12 +29,14 @@ namespace SEE.Game.Operator
         /// Also called each time the animator resumes playing from a paused state.
         /// </summary>
         /// <returns>Returns a reference to this object for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="callback"/> is null.</exception>
         IOperationCallback<T> OnPlay(T callback);
 
         /// <summary>
         /// Sets a callback that will be fired when the animator state changes from playing to paused.
         /// </summary>
         /// <returns>Returns a reference to this object for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="callback"/> is null.</exception>
         IOperationCallback<T> OnPause(T callback);
 
         /// <summary>
@@ -43,6 +47,7 @@ namespace SEE.Game.Operator
         /// Rewinding an animator that is already rewinded will not fire this callback.
         /// </remarks>
         /// <returns>Returns a reference to this object for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="callback"/> is null.</exception>
         IOperationCallback<T> OnRewind(T callback);
 
         /// <summary>
@@ -50,12 +55,14 @@ namespace SEE.Game.Operator
         /// playing state the first time, after any eventual delay).
         /// </summary>
         /// <returns>Returns a reference to this object for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="callback"/> is null.</exception>
         IOperationCallback<T> OnStart(T callback);
 
         /// <summary>
         /// Sets a callback that will be fired every time the animator updates.
         /// </summary>
         /// <returns>Returns a reference to this object for chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="callback"/> is null.</exception>
         IOperationCallback<T> OnUpdate(T callback);
 
         // Missing from DOTween, we can add them once we need them: OnStepComplete, OnWaypointChange

--- a/Assets/SEE/Game/Operator/TweenOperationCallback.cs
+++ b/Assets/SEE/Game/Operator/TweenOperationCallback.cs
@@ -26,36 +26,60 @@ namespace SEE.Game.Operator
 
         public IOperationCallback<TweenCallback> OnComplete(TweenCallback callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             targetTween.OnComplete((TweenCallback)Delegate.Combine(targetTween.onComplete, callback));
             return this;
         }
 
         public IOperationCallback<TweenCallback> OnKill(TweenCallback callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             targetTween.OnKill((TweenCallback)Delegate.Combine(targetTween.onKill, callback));
             return this;
         }
 
         public IOperationCallback<TweenCallback> OnPlay(TweenCallback callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             targetTween.OnPlay((TweenCallback)Delegate.Combine(targetTween.onPlay, callback));
             return this;
         }
 
         public IOperationCallback<TweenCallback> OnPause(TweenCallback callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             targetTween.OnPause((TweenCallback)Delegate.Combine(targetTween.onPause, callback));
             return this;
         }
 
         public IOperationCallback<TweenCallback> OnRewind(TweenCallback callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             targetTween.OnRewind((TweenCallback)Delegate.Combine(targetTween.onRewind, callback));
             return this;
         }
 
         public IOperationCallback<TweenCallback> OnUpdate(TweenCallback callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             targetTween.OnUpdate((TweenCallback)Delegate.Combine(targetTween.onUpdate, callback));
             return this;
         }
@@ -67,6 +91,10 @@ namespace SEE.Game.Operator
         /// </summary>
         public IOperationCallback<TweenCallback> OnStart(TweenCallback callback)
         {
+            if (callback == null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
             // We can't combine delegates here because `onStart` is an internal property in DOTween.
             targetTween.OnStart(callback);
             return this;

--- a/Assets/SEE/Layout/NodeLayouts/EvoStreets/ENode.cs
+++ b/Assets/SEE/Layout/NodeLayouts/EvoStreets/ENode.cs
@@ -301,9 +301,11 @@ namespace SEE.Layout.NodeLayouts.EvoStreets
         /// <param name="streetHeight">Will be ignored.</param>
         public override void ToLayout(ref Dictionary<ILayoutNode, NodeTransform> layoutResult, float streetHeight)
         {
+            /// A leaf will keep its original height (the one by <see cref="GraphNode"/>).
+            /// We only adjust the width and depth according to the calculated layout.
             layoutResult[GraphNode] = new NodeTransform(Rectangle.Center.X, Rectangle.Center.Y,
-                                                         new Vector3 (Rectangle.Width, GraphNode.AbsoluteScale.y, Rectangle.Depth),
-                                                         0);
+                                                        new Vector3 (Rectangle.Width, GraphNode.AbsoluteScale.y, Rectangle.Depth),
+                                                        0);
         }
     }
 
@@ -559,9 +561,12 @@ namespace SEE.Layout.NodeLayouts.EvoStreets
         /// method adds the data from <see cref="street"/> because that rectangle is used to depict an inner
         /// node. The attribute <see cref="Rectangle"/> is just the area enclosing this street and all
         /// representations of the descendants of this node.
+        ///
+        /// This method recurses into the <see cref="children"/>.
         /// </summary>
         /// <param name="layoutResult">Layout where to add the layout information.</param>
-        /// <param name="streetHeight">The height of an inner node (depicted as street).</param>
+        /// <param name="streetHeight">The height of an inner node (depicted as street).
+        /// Will be used for the height of the node.</param>
         public override void ToLayout(ref Dictionary<ILayoutNode, NodeTransform> layoutResult, float streetHeight)
         {
             layoutResult[GraphNode]

--- a/Assets/SEE/Layout/NodeLayouts/EvoStreetsNodeLayout.cs
+++ b/Assets/SEE/Layout/NodeLayouts/EvoStreetsNodeLayout.cs
@@ -55,11 +55,10 @@ namespace SEE.Layout.NodeLayouts
             if (layoutNodes.Count == 1)
             {
                 ILayoutNode singleNode = layoutNodes.First();
-                Dictionary<ILayoutNode, NodeTransform> layoutResult = new()
+                return new Dictionary<ILayoutNode, NodeTransform>()
                 {
                     [singleNode] = new NodeTransform(0, 0, singleNode.AbsoluteScale)
                 };
-                return layoutResult;
             }
 
             Roots = LayoutNodes.GetRoots(layoutNodes);

--- a/Assets/SEE/Layout/NodeLayouts/EvoStreetsNodeLayout.cs
+++ b/Assets/SEE/Layout/NodeLayouts/EvoStreetsNodeLayout.cs
@@ -72,21 +72,19 @@ namespace SEE.Layout.NodeLayouts
                 throw new Exception("Graph has multiple roots.");
             }
 
-            {
-                LayoutDescriptor treeDescriptor;
-                treeDescriptor.StreetWidth = CalculateStreetWidth(layoutNodes);
-                treeDescriptor.OffsetBetweenBuildings = treeDescriptor.StreetWidth * offsetBetweenBuildingsPercentage;
-                ILayoutNode root = Roots.FirstOrDefault();
-                ENode rootNode = GenerateHierarchy(root);
-                treeDescriptor.MaximalDepth = MaxDepth(root);
+            LayoutDescriptor treeDescriptor;
+            treeDescriptor.StreetWidth = CalculateStreetWidth(layoutNodes);
+            treeDescriptor.OffsetBetweenBuildings = treeDescriptor.StreetWidth * offsetBetweenBuildingsPercentage;
+            ILayoutNode root = Roots.FirstOrDefault();
+            ENode rootNode = GenerateHierarchy(root);
+            treeDescriptor.MaximalDepth = MaxDepth(root);
 
-                rootNode.SetSize(Orientation.East, treeDescriptor);
-                rootNode.SetLocation(Orientation.East, new Location(0, 0));
+            rootNode.SetSize(Orientation.East, treeDescriptor);
+            rootNode.SetLocation(Orientation.East, new Location(0, 0));
 
-                Dictionary<ILayoutNode, NodeTransform> layoutResult = new();
-                rootNode.ToLayout(ref layoutResult, streetHeight);
-                return layoutResult;
-            }
+            Dictionary<ILayoutNode, NodeTransform> layoutResult = new();
+            rootNode.ToLayout(ref layoutResult, streetHeight);
+            return layoutResult;
         }
 
         /// <summary>

--- a/Assets/SEE/Layout/NodeLayouts/EvoStreetsNodeLayout.cs
+++ b/Assets/SEE/Layout/NodeLayouts/EvoStreetsNodeLayout.cs
@@ -49,11 +49,13 @@ namespace SEE.Layout.NodeLayouts
             IList<ILayoutNode> layoutNodes = gameNodes.ToList();
             if (layoutNodes.Count == 0)
             {
+                /// Empty graph => empty layout.
                 return new Dictionary<ILayoutNode, NodeTransform>();
             }
 
             if (layoutNodes.Count == 1)
             {
+                /// Graph with only one node => node is placed at the center with given scale.
                 ILayoutNode singleNode = layoutNodes.First();
                 return new Dictionary<ILayoutNode, NodeTransform>()
                 {
@@ -64,17 +66,20 @@ namespace SEE.Layout.NodeLayouts
             Roots = LayoutNodes.GetRoots(layoutNodes);
             if (Roots.Count == 0)
             {
+                /// We can never arrive here because we made sure above that we have at least one node.
                 throw new Exception("Graph has no root node.");
             }
 
             if (Roots.Count > 1)
             {
+                /// Graph must have a single root.
                 throw new Exception("Graph has multiple roots.");
             }
 
             LayoutDescriptor treeDescriptor;
             treeDescriptor.StreetWidth = CalculateStreetWidth(layoutNodes);
             treeDescriptor.OffsetBetweenBuildings = treeDescriptor.StreetWidth * offsetBetweenBuildingsPercentage;
+            /// We have exactly one root. See above.
             ILayoutNode root = Roots.FirstOrDefault();
             ENode rootNode = GenerateHierarchy(root);
             treeDescriptor.MaximalDepth = MaxDepth(root);
@@ -112,18 +117,20 @@ namespace SEE.Layout.NodeLayouts
         }
 
         /// <summary>
-        /// Creates the ENode tree hierarchy starting at given root node. The root has
-        /// depth 0.
+        /// Creates the <see cref="ENode"/> tree hierarchy starting at given <paramref name="node"/>.
+        /// The root has depth 0.
         /// </summary>
-        /// <param name="root">Root of the hierarchy.</param>
+        /// <param name="node">Currently processed node.</param>
+        /// <param name="depth">The current depth of <paramref name="node"/> in the hierarchy.
+        /// The root has depth 0.</param>
         /// <returns>Root ENode.</returns>
-        private static ENode GenerateHierarchy(ILayoutNode root, int depth = 0)
+        private static ENode GenerateHierarchy(ILayoutNode node, int depth = 0)
         {
-            ENode result = ENodeFactory.Create(root);
+            ENode result = ENodeFactory.Create(node);
             result.TreeDepth = depth;
             if (result is EInner inner)
             {
-                foreach (ILayoutNode child in root.Children())
+                foreach (ILayoutNode child in node.Children())
                 {
                     inner.AddChild(GenerateHierarchy(child, depth + 1));
                 }

--- a/Assets/SEE/Layout/NodeLayouts/NodeLayout.cs
+++ b/Assets/SEE/Layout/NodeLayouts/NodeLayout.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -442,7 +443,7 @@ namespace SEE.Layout.NodeLayouts
         /// </summary>
         /// <param name="layoutNodes">Nodes to be printed.</param>
         /// <remarks>Intended for debugging.</remarks>
-        protected void Dump(IEnumerable<ILayoutNode> layoutNodes)
+        protected static void Dump(IEnumerable<ILayoutNode> layoutNodes)
         {
             foreach (ILayoutNode node in layoutNodes)
             {
@@ -455,11 +456,23 @@ namespace SEE.Layout.NodeLayouts
         /// </summary>
         /// <param name="layout">Layout to be printed.</param>
         /// <remarks>Intended for debugging.</remarks>
-        protected void Dump(Dictionary<ILayoutNode, NodeTransform> layout)
+        public static void Dump(Dictionary<ILayoutNode, NodeTransform> layout)
         {
-            foreach (KeyValuePair<ILayoutNode, NodeTransform> entry in layout)
+            foreach (ILayoutNode root in layout.Keys.Where(n => n.Parent == null))
             {
-                Debug.Log($"{entry.Key} => {entry.Value}\n");
+                Dump(root, 0);
+            }
+
+            void Dump(ILayoutNode node, int level)
+            {
+                string indent = new string(' ', 6 * level);
+                string marker = level > 0 ? "└── " : "";
+                Debug.Log($"{indent}{marker}{node.ID} => {layout[node]}\n");
+
+                foreach (ILayoutNode child in node.Children())
+                {
+                    Dump(child, level + 1);
+                }
             }
         }
 

--- a/Assets/SEE/Net/Actions/Animation/AnimationNetAction.cs
+++ b/Assets/SEE/Net/Actions/Animation/AnimationNetAction.cs
@@ -14,7 +14,7 @@ namespace SEE.Net.Actions.Animation
         /// The unique full (hierarchical) name of the gameObject holding an <see cref="AnimationInteraction"/>
         /// component that needs to be triggered.
         /// </summary>
-        public string GameObjectID;
+        public readonly string GameObjectID;
 
         /// <summary>
         /// Constructor.
@@ -47,11 +47,6 @@ namespace SEE.Net.Actions.Animation
                 return ai;
             }
             throw new Exception($"GameObject with ID {gameObjectID} does not have an {nameof(AnimationInteraction)} component.");
-        }
-
-        public override void ExecuteOnServer()
-        {
-            // Intentionally left blank.
         }
 
         /// <summary>

--- a/Assets/SEE/Net/Actions/Animation/AnimationNetAction.cs
+++ b/Assets/SEE/Net/Actions/Animation/AnimationNetAction.cs
@@ -14,7 +14,7 @@ namespace SEE.Net.Actions.Animation
         /// The unique full (hierarchical) name of the gameObject holding an <see cref="AnimationInteraction"/>
         /// component that needs to be triggered.
         /// </summary>
-        public readonly string GameObjectID;
+        public string GameObjectID;
 
         /// <summary>
         /// Constructor.


### PR DESCRIPTION
Fixes #965 and #929.

The callback registering methods in `AndCombinedOperationCallback` now chain their callbacks instead of overriding the existing one.

In addition, some minor improvements were applied to some of the EvoStreets classes and in `AnimationNetAction`.

Closes #965 and closes #929.
