### PR TITLE
981 migrate our test cases to nunit with constraints

### DIFF
--- a/Assets/Plugins/Dissonance/Demo/GroundMaterial.mat
+++ b/Assets/Plugins/Dissonance/Demo/GroundMaterial.mat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1a7c0ea7f5d433950807698ea78ef84849ad0e4b493a29e22b4faa5e48ad00c
-size 5024
+oid sha256:c083f50f72eddecc42d348f1872d5e663320a9d1493d2b81c35bb3121170b78b
+size 3804

--- a/Assets/Plugins/HighlightPlus/Demo/URP settings/UniversalRenderPipelineAsset.asset
+++ b/Assets/Plugins/HighlightPlus/Demo/URP settings/UniversalRenderPipelineAsset.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a45f38b6408dc0484b1031e5995439854704396b65575526f4ad0f4ba44d0c88
-size 3659
+oid sha256:932ebe36463c2254c1610f47de0dc22cbbb876b729a3c988dfd2ebd1a1cd6883
+size 4421

--- a/Assets/SEE/Controls/Actions/AddEdgeAction.cs
+++ b/Assets/SEE/Controls/Actions/AddEdgeAction.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-﻿using SEE.Game;
+using SEE.Game;
 using SEE.UI.Notification;
 using SEE.GO;
 using SEE.Net.Actions;

--- a/Assets/SEE/DataModel/DG/Graph.cs
+++ b/Assets/SEE/DataModel/DG/Graph.cs
@@ -1483,6 +1483,7 @@ namespace SEE.DataModel.DG
         /// </summary>
         /// <param name="other">To be compared to.</param>
         /// <returns>True if equal.</returns>
+        /// <remarks>The comparison is value based, not reference based.</remarks>
         public override bool Equals(object other)
         {
             return (other is Graph otherGraph) && (GetType() == otherGraph.GetType())

--- a/Assets/SEE/Game/CityRendering/GameNodeHierarchy.cs
+++ b/Assets/SEE/Game/CityRendering/GameNodeHierarchy.cs
@@ -3,7 +3,6 @@ using SEE.GO;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace SEE.Game.CityRendering
 {

--- a/Assets/SEE/Game/CityRendering/GameNodeHierarchy.cs
+++ b/Assets/SEE/Game/CityRendering/GameNodeHierarchy.cs
@@ -56,37 +56,6 @@ namespace SEE.Game.CityRendering
                     }
                 }
             }
-
-            /// <summary>
-            /// Checks whether all graph nodes and game nodes in <paramref name="nodeMap"/> are
-            /// members of the same graph. Emits warnings and asserts that they are all in
-            /// the same graph.
-            /// Used only for debugging.
-            /// </summary>
-            /// <param name="nodeMap">Mapping of graph nodes onto their corresponding game nodes.</param>
-            static void Check(Dictionary<Node, GameObject> nodeMap)
-            {
-                HashSet<Graph> graphs = new();
-
-                foreach (GameObject go in nodeMap.Values)
-                {
-                    graphs.Add(go.GetNode().ItsGraph);
-                }
-                foreach (Node node in nodeMap.Keys)
-                {
-                    graphs.Add(node.ItsGraph);
-                }
-                if (graphs.Count > 1)
-                {
-                    Debug.LogError("There are nodes from different graphs in the same game-node hierarchy!\n");
-                    foreach (GameObject go in nodeMap.Values)
-                    {
-                        Node node = go.GetNode();
-                        Debug.LogWarning($"Node {node.ID} contained in graph {node.ItsGraph.Name} from file {node.ItsGraph.Path}\n");
-                    }
-                }
-                Assert.AreEqual(1, graphs.Count);
-            }
         }
     }
 }

--- a/Assets/SEE/Game/SceneQueries.cs
+++ b/Assets/SEE/Game/SceneQueries.cs
@@ -3,7 +3,6 @@ using SEE.DataModel.DG;
 using SEE.GO;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace SEE.Game

--- a/Assets/SEE/Game/SceneQueries.cs
+++ b/Assets/SEE/Game/SceneQueries.cs
@@ -81,19 +81,6 @@ namespace SEE.Game
         }
 
         /// <summary>
-        /// Returns the roots of all graphs currently represented by any of the <paramref name="gameNodes"/>.
-        ///
-        /// Precondition: Every game object in <paramref name="gameNodes"/> must be tagged by
-        /// Tags.Node and have a valid graph node reference.
-        /// </summary>
-        /// <param name="gameNodes">Game nodes whose roots are to be returned.</param>
-        /// <returns>All root nodes in the scene.</returns>
-        public static List<Node> GetRoots(IEnumerable<GameObject> gameNodes)
-        {
-            return GetGraphs(gameNodes).SelectMany(graph => graph.GetRoots()).ToList();
-        }
-
-        /// <summary>
         /// Returns the roots of all graphs currently referenced by any of the <paramref name="nodeRefs"/>.
         /// </summary>
         /// <param name="nodeRefs">References to nodes in any graphs whose roots are to be returned.</param>

--- a/Assets/SEE/Game/SceneQueries.cs
+++ b/Assets/SEE/Game/SceneQueries.cs
@@ -1,6 +1,5 @@
 ﻿using SEE.Controls;
 using SEE.DataModel.DG;
-using SEE.Game.City;
 using SEE.GO;
 using System;
 using System.Collections.Generic;
@@ -103,19 +102,6 @@ namespace SEE.Game
                 }
             }
             return result;
-        }
-
-        /// <summary>
-        /// Returns all graphs currently represented by any of the <paramref name="gameNodes"/>.
-        ///
-        /// Precondition: Every game object in <paramref name="gameNodes"/> must be tagged by
-        /// Tags.Node and have a valid graph node reference.
-        /// </summary>
-        /// <param name="gameNodes">Game nodes whose graph is to be returned.</param>
-        /// <returns>All graphs in the scene.</returns>
-        public static HashSet<Graph> GetGraphs(IEnumerable<GameObject> gameNodes)
-        {
-            return gameNodes.Select(go => go.GetComponent<NodeRef>().Value.ItsGraph).ToHashSet();
         }
 
         /// <summary>

--- a/Assets/SEE/GameObjects/CityCursor.cs
+++ b/Assets/SEE/GameObjects/CityCursor.cs
@@ -107,7 +107,7 @@ namespace SEE.GO
                 Graph selectedGraph = graphElement.GraphElemRef.Elem.ItsGraph;
                 if (selectedGraph != null
                     && city.LoadedGraph != null
-                    && selectedGraph.Equals(city.LoadedGraph))
+                    && selectedGraph == city.LoadedGraph)
                 {
                     Cursor.AddFocus(interactableObject);
                     hoverStartTimes[interactableObject] = Time.time;
@@ -136,7 +136,7 @@ namespace SEE.GO
                 && interactableObject is InteractableGraphElement graphElement)
             {
                 Graph selectedGraph = graphElement.GraphElemRef.Elem.ItsGraph;
-                if (selectedGraph != null && selectedGraph.Equals(city.LoadedGraph))
+                if (selectedGraph != null && selectedGraph == city.LoadedGraph)
                 {
                     Cursor.RemoveFocus(interactableObject);
 

--- a/Assets/SEE/UserSettings/UserSettings.cs
+++ b/Assets/SEE/UserSettings/UserSettings.cs
@@ -1,5 +1,4 @@
 ﻿using DG.Tweening;
-using OpenAI.Realtime;
 using SEE.GO;
 using SEE.Net;
 using SEE.Tools.OpenTelemetry;

--- a/Assets/SEEPlayModeTests/TestDoTween.cs
+++ b/Assets/SEEPlayModeTests/TestDoTween.cs
@@ -72,9 +72,9 @@ namespace DoTween
             yield return new WaitForSeconds(0.2f);
 
             // Assertions
-            Assert.IsTrue(onCompleteCalled, "OnComplete should have been called.");
-            Assert.IsTrue(onKillCalled, "OnKill should have been called.");
-            Assert.IsTrue(order == 2, "OnKill should have been called after completion.");
+            Assert.That(onCompleteCalled, Is.True, "OnComplete should have been called.");
+            Assert.That(onKillCalled, Is.True, "OnKill should have been called.");
+            Assert.That(order, Is.EqualTo(2), "OnKill should have been called after completion.");
         }
 
         // ---------------------------------------------------------
@@ -99,8 +99,8 @@ namespace DoTween
             myTween.Kill();
 
             // Assertions
-            Assert.IsFalse(onCompleteCalled, "OnComplete should NOT be called on manual kill.");
-            Assert.IsTrue(onKillCalled, "OnKill SHOULD be called on manual kill.");
+            Assert.That(onCompleteCalled, Is.False, "OnComplete should NOT be called on manual kill.");
+            Assert.That(onKillCalled, Is.True, "OnKill SHOULD be called on manual kill.");
         }
 
         // ---------------------------------------------------------
@@ -128,8 +128,8 @@ namespace DoTween
             yield return null;
 
             // Assertions
-            Assert.IsFalse(onCompleteCalled, "OnComplete should NOT be called when object is destroyed.");
-            Assert.IsTrue(onKillCalled, "OnKill SHOULD be called when object is destroyed.");
+            Assert.That(onCompleteCalled, Is.False, "OnComplete should NOT be called when object is destroyed.");
+            Assert.That(onKillCalled, Is.True, "OnKill SHOULD be called when object is destroyed.");
         }
 
         // -------------------------------------------------------------------
@@ -152,8 +152,8 @@ namespace DoTween
             yield return new WaitForSeconds(0.2f);
 
             // Assertions
-            Assert.IsFalse(onKillCalled1, "First OnKill should NOT be called.");
-            Assert.IsTrue(onKillCalled2, "Second OnKill should be called.");
+            Assert.That(onKillCalled1, Is.False, "First OnKill should NOT be called.");
+            Assert.That(onKillCalled2, Is.True, "Second OnKill should be called.");
         }
 
         // -----------------------------------------------------------------------
@@ -176,8 +176,8 @@ namespace DoTween
             yield return new WaitForSeconds(0.2f);
 
             // Assertions
-            Assert.IsFalse(onCompleteCalled1, "First OnComplete should NOT be called.");
-            Assert.IsTrue(onCompleteCalled2, "Second OnComplete should be called.");
+            Assert.That(onCompleteCalled1, Is.False, "First OnComplete should NOT be called.");
+            Assert.That(onCompleteCalled2, Is.True, "Second OnComplete should be called.");
         }
 
     }

--- a/Assets/SEEPlayModeTests/TestKeywordInput.cs
+++ b/Assets/SEEPlayModeTests/TestKeywordInput.cs
@@ -60,7 +60,8 @@ namespace SEE.Controls
             Debug.Log(builder.ToString());
 
             // Make sure whatever was recognized is one of the expected keywords.
-            Assert.That(keywords.Any(keyword => args.text == keyword));
+            Assert.That(keywords, Has.Member(args.text),
+                        $"'{args.text}' is not one of the expected keywords.");
         }
 
         /// <summary>

--- a/Assets/SEEPlayModeTests/TestMenu.cs
+++ b/Assets/SEEPlayModeTests/TestMenu.cs
@@ -109,9 +109,10 @@ namespace SEE.UI.Menu
         {
             // Retrieve the button
             GameObject buttonObject = GameObject.Find(buttonPath);
-            Assert.NotNull(buttonObject, $"Button path {buttonPath} not found.");
+            Assert.That(buttonObject, Is.Not.Null, $"Button path {buttonPath} not found.");
             // Make sure the object is really holding a button.
-            Assert.That(buttonObject.TryGetComponent(out Button _));
+            Assert.That(buttonObject.TryGetComponent(out Button _), Is.True,
+                        $"Game object {buttonPath} has no {nameof(Button)} component.");
             // Press the button.
             ExecuteEvents.Execute(buttonObject, new BaseEventData(EventSystem.current), ExecuteEvents.submitHandler);
         }

--- a/Assets/SEEPlayModeTests/TestMenu.cs
+++ b/Assets/SEEPlayModeTests/TestMenu.cs
@@ -111,7 +111,7 @@ namespace SEE.UI.Menu
             GameObject buttonObject = GameObject.Find(buttonPath);
             Assert.That(buttonObject, Is.Not.Null, $"Button path {buttonPath} not found.");
             // Make sure the object is really holding a button.
-            Assert.That(buttonObject.TryGetComponent(out Button _), Is.True,
+            Assert.That(buttonObject.GetComponent<Button>(), Is.Not.Null,
                         $"Game object {buttonPath} has no {nameof(Button)} component.");
             // Press the button.
             ExecuteEvents.Execute(buttonObject, new BaseEventData(EventSystem.current), ExecuteEvents.submitHandler);

--- a/Assets/SEEPlayModeTests/TestNestedMenu.cs
+++ b/Assets/SEEPlayModeTests/TestNestedMenu.cs
@@ -58,7 +58,7 @@ namespace SEE.UI.Menu
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
             PressButton(MenuTitle, OptionOne);
             yield return new WaitForEndOfFrame();
-            Assert.AreEqual(OptionOneValue, selection);
+            Assert.That(selection, Is.EqualTo(OptionOneValue), $"Pressing {OptionOne} must select it.");
             yield return new WaitForEndOfFrame();
         }
 
@@ -75,7 +75,8 @@ namespace SEE.UI.Menu
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
             PressButton(SubMenuTitle, NestedOptionOne);
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
-             Assert.AreEqual(NestedOptionOneValue, selection);
+            Assert.That(selection, Is.EqualTo(NestedOptionOneValue),
+                        $"Pressing {NestedOptionOne} in {SubMenuTitle} must select it.");
             yield return new WaitForEndOfFrame();
         }
 
@@ -92,7 +93,8 @@ namespace SEE.UI.Menu
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
             PressButton(SubMenuTitle, NestedOptionTwo);
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
-            Assert.AreEqual(NestedOptionTwoValue, selection);
+            Assert.That(selection, Is.EqualTo(NestedOptionTwoValue),
+                        $"Pressing {NestedOptionTwo} in {SubMenuTitle} must select it.");
             yield return new WaitForEndOfFrame();
         }
 
@@ -107,7 +109,7 @@ namespace SEE.UI.Menu
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
             PressCloseButton(MenuTitle);
             yield return new WaitForEndOfFrame();
-            Assert.AreEqual(0, selection);
+            Assert.That(selection, Is.EqualTo(0), "Closing the menu must not select any option.");
             yield return new WaitForEndOfFrame();
         }
 

--- a/Assets/SEEPlayModeTests/TestPropertyDialog.cs
+++ b/Assets/SEEPlayModeTests/TestPropertyDialog.cs
@@ -54,40 +54,46 @@ namespace SEE.UI.PropertyDialog
             yield return new WaitForSeconds(1f);
 
             GameObject canvas = GameObject.Find("UI Canvas");
-            Assert.NotNull(canvas);
+            Assert.That(canvas, Is.Not.Null, "There is no UI Canvas.");
 
             // Simulate entering the text in the input field.
             GameObject stringPropertyGameObject = GameObject.Find(stringProperty.Name);
-            Assert.NotNull(stringPropertyGameObject);
+            Assert.That(stringPropertyGameObject, Is.Not.Null,
+                        $"There is no game object named {stringProperty.Name}.");
             TMP_InputField textField = GetInputField(stringPropertyGameObject);
-            Assert.NotNull(textField);
+            Assert.That(textField, Is.Not.Null,
+                        $"{stringProperty.Name} has no {nameof(TMP_InputField)} component.");
             textField.text = "Expected Value";
 
             // Simulate forward clicking of the selector (twice).
             GameObject selectionPropertyGameObject = GameObject.Find(selectionProperty.Name);
-            Assert.NotNull(selectionPropertyGameObject);
+            Assert.That(selectionPropertyGameObject, Is.Not.Null,
+                        $"There is no game object named {selectionProperty.Name}.");
             HorizontalSelector selector = GetHorizontalSelector(selectionPropertyGameObject);
-            Assert.NotNull(selectionPropertyGameObject);
+            Assert.That(selector, Is.Not.Null,
+                        $"{selectionProperty.Name} has no {nameof(HorizontalSelector)} component.");
             // We have three options and we have initially set the second option, so we can move
             // forward once maximally.
             selector.ForwardClick();
-            Assert.AreEqual(options[2], selectionProperty.Value);
+            Assert.That(selectionProperty.Value, Is.EqualTo(options[2]));
             selector.PreviousClick();
-            Assert.AreEqual(options[1], selectionProperty.Value);
+            Assert.That(selectionProperty.Value, Is.EqualTo(options[1]));
             selector.PreviousClick();
-            Assert.AreEqual(options[0], selectionProperty.Value);
+            Assert.That(selectionProperty.Value, Is.EqualTo(options[0]));
 
             // Simulate that the OK button is pressed by the user.
             GameObject okButton = GameObject.Find("OK");
-            Assert.NotNull(okButton);
-            Assert.That(okButton.TryGetComponent(out Button button));
+            Assert.That(okButton, Is.Not.Null, "There is no OK button.");
+            Assert.That(okButton.TryGetComponent(out Button button), Is.True,
+                        $"The OK button has no {nameof(Button)} component.");
             ExecuteEvents.Execute(okButton.gameObject, new BaseEventData(EventSystem.current), ExecuteEvents.submitHandler);
             yield return new WaitForEndOfFrame();
 
             // The entered text must be present.
-            Assert.AreEqual(stringProperty.Value, textField.text);
+            Assert.That(textField.text, Is.EqualTo(stringProperty.Value));
             // The callback has occurred.
-            Assert.That(CallbackHasOccurred);
+            Assert.That(CallbackHasOccurred, Is.True,
+                        "The OnConfirm callback must have been invoked.");
         }
 
         /// <summary>

--- a/Assets/SEEPlayModeTests/TestSEEGame.cs
+++ b/Assets/SEEPlayModeTests/TestSEEGame.cs
@@ -111,7 +111,8 @@ namespace SEE.Net
             Debug.Log($"[SetUp] Scene {StartScene} has been loaded...\n");
 
             // Make sure we have our network manager.
-            Assert.NotNull(Unity.Netcode.NetworkManager.Singleton);
+            Assert.That(Unity.Netcode.NetworkManager.Singleton, Is.Not.Null,
+                        $"There is no {nameof(Unity.Netcode.NetworkManager)} in scene {StartScene}.");
 
             // Simulate that the Host button in the Network Configuration dialog is
             // pressed by the user.
@@ -119,7 +120,8 @@ namespace SEE.Net
             PressButton(HostButtonPath);
             yield return new WaitForEndOfFrame();
 
-            Assert.NotNull(User.UserSettings.Instance);
+            Assert.That(User.UserSettings.Instance, Is.Not.Null,
+                        $"There is no {nameof(User.UserSettings)} instance after pressing {HostButtonPath}.");
             Debug.Log($"[SetUp] Finished.\n");
             yield return null;
         }
@@ -171,9 +173,10 @@ namespace SEE.Net
         {
             // Retrieve the button
             GameObject buttonObject = GameObject.Find(buttonPath);
-            Assert.NotNull(buttonObject);
+            Assert.That(buttonObject, Is.Not.Null, $"Button path {buttonPath} not found.");
             // Make sure the object is really holding a button.
-            Assert.That(buttonObject.TryGetComponent(out Button _));
+            Assert.That(buttonObject.GetComponent<Button>(), Is.Not.Null,
+                        $"Game object {buttonPath} has no {nameof(Button)} component.");
             // Press the button.
             ExecuteEvents.Execute(buttonObject, new BaseEventData(EventSystem.current), ExecuteEvents.submitHandler);
         }

--- a/Assets/SEEPlayModeTests/TestSimpleMenu.cs
+++ b/Assets/SEEPlayModeTests/TestSimpleMenu.cs
@@ -26,6 +26,7 @@ namespace SEE.UI.Menu
         /// </summary>
         private const string MenuTitle = "Test Menu";
 
+        /// <summary>
         /// Test for selecting option 1.
         /// </summary>
         /// <returns><see cref="WaitForEndOfFrame"/></returns>
@@ -36,7 +37,7 @@ namespace SEE.UI.Menu
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
             PressButton(MenuTitle, OptionOne);
             yield return new WaitForEndOfFrame();
-            Assert.AreEqual(1, selection);
+            Assert.That(selection, Is.EqualTo(1), $"Pressing {OptionOne} must select option 1.");
             yield return new WaitForEndOfFrame();
         }
 
@@ -51,7 +52,7 @@ namespace SEE.UI.Menu
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
             PressButton(MenuTitle, OptionTwo);
             yield return new WaitForEndOfFrame();
-            Assert.AreEqual(2, selection);
+            Assert.That(selection, Is.EqualTo(2), $"Pressing {OptionTwo} must select option 2.");
             yield return new WaitForEndOfFrame();
         }
 
@@ -66,7 +67,7 @@ namespace SEE.UI.Menu
             yield return new WaitForSeconds(TimeUntilMenuIsSetup);
             PressCloseButton(MenuTitle);
             yield return new WaitForEndOfFrame();
-            Assert.AreEqual(0, selection);
+            Assert.That(selection, Is.EqualTo(0), "Closing the menu must not select any option.");
             yield return new WaitForEndOfFrame();
         }
 

--- a/Assets/SEEPlayModeTests/TestUI.cs
+++ b/Assets/SEEPlayModeTests/TestUI.cs
@@ -17,7 +17,8 @@ namespace SEE.UI
         /// <summary>
         /// Setup for a test.
         /// The playmode will be entered.
-        /// The <see cref="User.UserSettings.Instance.InputType"/> will be <see cref="SEE.GO.PlayerInputType.DesktopPlayer"/>.
+        /// The <see cref="User.UserSettings.InputType">UserSettings.Instance.InputType</see>
+        /// will be <see cref="GO.PlayerInputType.DesktopPlayer"/>.
         ///
         /// Note: Subclasses may have their own method tagged by UnitySetUp,
         /// which will then be called after this method.

--- a/Assets/SEEPlayModeTests/TestUI.cs
+++ b/Assets/SEEPlayModeTests/TestUI.cs
@@ -17,7 +17,7 @@ namespace SEE.UI
         /// <summary>
         /// Setup for a test.
         /// The playmode will be entered.
-        /// The <see cref="SceneSettings.InputType"/> will be <see cref="SEE.GO.PlayerInputType.DesktopPlayer"/>.
+        /// The <see cref="User.UserSettings.Instance.InputType"/> will be <see cref="SEE.GO.PlayerInputType.DesktopPlayer"/>.
         ///
         /// Note: Subclasses may have their own method tagged by UnitySetUp,
         /// which will then be called after this method.

--- a/Assets/SEETests/AbstractTestConfigIO.cs
+++ b/Assets/SEETests/AbstractTestConfigIO.cs
@@ -16,9 +16,9 @@ namespace SEE.Utils
         /// <param name="actual">actual data path</param>
         protected static void AreEqual(DataPath expected, DataPath actual)
         {
-            Assert.AreEqual(expected.Root, actual.Root);
-            Assert.AreEqual(expected.RelativePath, actual.RelativePath);
-            Assert.AreEqual(expected.AbsolutePath, actual.AbsolutePath);
+            Assert.That(actual.Root, Is.EqualTo(expected.Root), "Root of the data path.");
+            Assert.That(actual.RelativePath, Is.EqualTo(expected.RelativePath), "Relative path of the data path.");
+            Assert.That(actual.AbsolutePath, Is.EqualTo(expected.AbsolutePath), "Absolute path of the data path.");
         }
     }
 }

--- a/Assets/SEETests/TestActionHistory.cs
+++ b/Assets/SEETests/TestActionHistory.cs
@@ -47,28 +47,30 @@ namespace SEE.Utils.History
             {
                 AwakeCalls++;
                 // Called exactly once before any other method.
-                Assert.AreEqual(1, AwakeCalls);
-                Assert.AreEqual(0, StartCalls);
-                Assert.AreEqual(0, UpdateCalls);
-                Assert.AreEqual(0, StopCalls);
+                Assert.That(AwakeCalls, Is.EqualTo(1));
+                Assert.That(StartCalls, Is.EqualTo(0));
+                Assert.That(UpdateCalls, Is.EqualTo(0));
+                Assert.That(StopCalls, Is.EqualTo(0));
             }
 
             public void Start()
             {
                 StartCalls++;
                 // AwakeCalls has been called once before.
-                Assert.AreEqual(1, AwakeCalls);
+                Assert.That(AwakeCalls, Is.EqualTo(1));
                 // The number of Start calls is always one ahead of the number of Stop calls.
-                Assert.AreEqual(StartCalls, StopCalls + 1);
+                Assert.That(StartCalls, Is.EqualTo(StopCalls + 1),
+                            "Start must have been called once more often than Stop.");
             }
 
             public void Stop()
             {
                 StopCalls++;
                 // AwakeCalls has been called once before.
-                Assert.AreEqual(1, AwakeCalls);
+                Assert.That(AwakeCalls, Is.EqualTo(1));
                 // Each Stop must have a corresponding Start.
-                Assert.AreEqual(StartCalls, StopCalls);
+                Assert.That(StartCalls, Is.EqualTo(StopCalls),
+                            "Start and Stop must have been called equally often.");
             }
 
             public void Undo()
@@ -76,16 +78,20 @@ namespace SEE.Utils.History
                 IsOn = false;
                 UndoCalls++;
                 // If Undo is called, Stop must have been called before.
-                Assert.That(StopCalls > 0);
-                Assert.AreEqual(StartCalls, StopCalls);
-                Assert.That(UndoCalls == RedoCalls + 1);
+                Assert.That(StopCalls, Is.GreaterThan(0),
+                            "Stop must have been called before Undo.");
+                Assert.That(StartCalls, Is.EqualTo(StopCalls),
+                            "Start and Stop must have been called equally often.");
+                Assert.That(UndoCalls, Is.EqualTo(RedoCalls + 1),
+                            "Undo must have been called once more often than Redo.");
             }
 
             public void Redo()
             {
                 IsOn = true;
                 RedoCalls++;
-                Assert.That(UndoCalls == RedoCalls);
+                Assert.That(UndoCalls, Is.EqualTo(RedoCalls),
+                            "Undo and Redo must have been called equally often.");
             }
 
             public bool Update()
@@ -93,9 +99,10 @@ namespace SEE.Utils.History
                 IsOn = true;
                 UpdateCalls++;
                 // AwakeCalls has been called once before.
-                Assert.AreEqual(1, AwakeCalls);
+                Assert.That(AwakeCalls, Is.EqualTo(1));
                 // The number of Start calls is always one ahead of the number of Stop calls.
-                Assert.AreEqual(StartCalls, StopCalls + 1);
+                Assert.That(StartCalls, Is.EqualTo(StopCalls + 1),
+                            "Start must have been called once more often than Stop.");
                 // This action is never finished.
                 return false;
             }
@@ -254,7 +261,7 @@ namespace SEE.Utils.History
             // c4 is undone; execution will resume with c3, because c3 is still
             // in progress (TestAction.Update() always yields false).
             hist.Undo();
-            Assert.AreEqual(3, hist.UndoCount());
+            Assert.That(hist.UndoCount(), Is.EqualTo(3));
             CheckCalls(c1, value: true,  awake: 1, start: 1, update: 1, stop: 1);
             CheckCalls(c2, value: true,  awake: 1, start: 1, update: 1, stop: 1);
             CheckCalls(c3, value: true,  awake: 1, start: 2, update: 1, stop: 1);
@@ -429,11 +436,11 @@ namespace SEE.Utils.History
         /// <param name="stop">expected number of Stop() calls</param>
         private static void CheckCalls(TestAction counter, bool value, int awake, int start, int update, int stop)
         {
-            Assert.AreEqual(value, counter.IsOn, "IsOn not matching");
-            Assert.AreEqual(awake, counter.AwakeCalls, "awake calls not matching");
-            Assert.AreEqual(start, counter.StartCalls, "start calls not matching");
-            Assert.AreEqual(update, counter.UpdateCalls, "update calls not matching");
-            Assert.AreEqual(stop, counter.StopCalls, "stop calls not matching");
+            Assert.That(counter.IsOn, Is.EqualTo(value), "IsOn not matching");
+            Assert.That(counter.AwakeCalls, Is.EqualTo(awake), "awake calls not matching");
+            Assert.That(counter.StartCalls, Is.EqualTo(start), "start calls not matching");
+            Assert.That(counter.UpdateCalls, Is.EqualTo(update), "update calls not matching");
+            Assert.That(counter.StopCalls, Is.EqualTo(stop), "stop calls not matching");
         }
 
         /// <summary>
@@ -603,89 +610,89 @@ namespace SEE.Utils.History
         public void TestCounterAction()
         {
             hist.Execute(new Increment());
-            Assert.AreEqual(0, Counter.Value);
-            Assert.AreEqual(1, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(0));
+            Assert.That(hist.UndoCount(), Is.EqualTo(1));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0));
             hist.Update();
-            Assert.AreEqual(1, Counter.Value);
-            Assert.AreEqual(2, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(1));
+            Assert.That(hist.UndoCount(), Is.EqualTo(2));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0));
             hist.Update();
-            Assert.AreEqual(2, Counter.Value);
-            Assert.AreEqual(3, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(2));
+            Assert.That(hist.UndoCount(), Is.EqualTo(3));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0));
             hist.Update();
-            Assert.AreEqual(3, Counter.Value);
-            Assert.AreEqual(4, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(3));
+            Assert.That(hist.UndoCount(), Is.EqualTo(4));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0));
             // Because Increment.Update yields true every time it is called,
             // the execution will always continue with a new instance of
             // Increment. We have had three calls to Update. Including the
             // first Execute, we should have four actions on the UndoStack.
-            Assert.AreEqual(4, hist.UndoCount());
+            Assert.That(hist.UndoCount(), Is.EqualTo(4));
             hist.Undo();
-            Assert.AreEqual(2, Counter.Value);
+            Assert.That(Counter.Value, Is.EqualTo(2));
             // Undo will remove one completed action and then resume with
             // a new instance of Increment.
-            Assert.AreEqual(3, hist.UndoCount());
-            Assert.AreEqual(1, hist.RedoCount());
+            Assert.That(hist.UndoCount(), Is.EqualTo(3));
+            Assert.That(hist.RedoCount(), Is.EqualTo(1));
             hist.Undo();
-            Assert.AreEqual(1, Counter.Value);
-            Assert.AreEqual(2, hist.UndoCount());
-            Assert.AreEqual(2, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(1));
+            Assert.That(hist.UndoCount(), Is.EqualTo(2));
+            Assert.That(hist.RedoCount(), Is.EqualTo(2));
             hist.Undo();
-            Assert.AreEqual(0, Counter.Value);
+            Assert.That(Counter.Value, Is.EqualTo(0));
             // The UndoStack has one completed Increment action and one
             // instance of Increment that has had no effect yet.
             // If Undo is called, all actions without any effect will
             // be removed. This leaves the single action with effect,
             // which then is moved from the UndoStack to the RedoStack.
             // Thus, the UndoStack will be empty at this point.
-            Assert.AreEqual(0, hist.UndoCount());
-            Assert.AreEqual(3, hist.RedoCount());
+            Assert.That(hist.UndoCount(), Is.EqualTo(0));
+            Assert.That(hist.RedoCount(), Is.EqualTo(3));
             hist.Redo();
-            Assert.AreEqual(1, Counter.Value);
+            Assert.That(Counter.Value, Is.EqualTo(1));
             // Redo moves an action from the RedoStack to the UndoStack.
             // Because that action was completed, a new instance of
             // Increment will be put onto the UndoStack that will be used
             // to resume.
-            Assert.AreEqual(2, hist.UndoCount());
-            Assert.AreEqual(2, hist.RedoCount());
+            Assert.That(hist.UndoCount(), Is.EqualTo(2));
+            Assert.That(hist.RedoCount(), Is.EqualTo(2));
             hist.Redo();
-            Assert.AreEqual(2, Counter.Value);
-            Assert.AreEqual(3, hist.UndoCount());
-            Assert.AreEqual(1, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(2));
+            Assert.That(hist.UndoCount(), Is.EqualTo(3));
+            Assert.That(hist.RedoCount(), Is.EqualTo(1));
             hist.Execute(new Decrement());
             // The new instance of the Increment action that was put on
             // the stack due to Redo above has not received any Update call.
             // Hence, it will be popped off the UndoStack. Thus, UndoCount
             // remains the same.
-            Assert.AreEqual(2, Counter.Value); // still 2 because no Update was called
-            Assert.AreEqual(3, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount()); // RedoStack is lost
+            Assert.That(Counter.Value, Is.EqualTo(2)); // still 2 because no Update was called
+            Assert.That(hist.UndoCount(), Is.EqualTo(3));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0)); // RedoStack is lost
             hist.Update();
             // Update has completed Decrement. A new instance of Decrement will
             // be put on the Undo stack.
-            Assert.AreEqual(1, Counter.Value);
-            Assert.AreEqual(4, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(1));
+            Assert.That(hist.UndoCount(), Is.EqualTo(4));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0));
             // No Update has been called for the new instance of Decrement just put
             // on the UndoStack, hence, the Decrement at the top of the UndoStack
             // has still progress state NoEffect. Thus it will be popped off the UndoStack
             // when the next Increment is added by the following line.
             hist.Execute(new Increment());
-            Assert.AreEqual(1, Counter.Value);  // still 1 because no Update was called
-            Assert.AreEqual(4, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(1));  // still 1 because no Update was called
+            Assert.That(hist.UndoCount(), Is.EqualTo(4));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0));
             // Undo without prior Update for the Increment just added; that means we are actually
             // undoing Decrement. The Increment will be popped off the UndoStack. Then the
             // Decrement will be undone and moved from the UndoStack to the RedoStack.
             // Now a completed Increment will be at the top of the stack. Because it is
             // completed, a new instance of Increment will be added.
             hist.Undo();
-            Assert.AreEqual(2, Counter.Value);
-            Assert.AreEqual(3, hist.UndoCount());
-            Assert.AreEqual(1, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(2));
+            Assert.That(hist.UndoCount(), Is.EqualTo(3));
+            Assert.That(hist.RedoCount(), Is.EqualTo(1));
             hist.Undo(); // undoing an Increment
             // No Update has been called for the new instance of the Increment with
             // progress state NoEffect. Hence, it will be popped off the UndoStack.
@@ -695,9 +702,9 @@ namespace SEE.Utils.History
             // executed) is at the top of the UndoStack again, and as a consequence
             // a new instance of Increment is added to the UndoStack in progress state
             // NoEffect.
-            Assert.AreEqual(1, Counter.Value);
-            Assert.AreEqual(2, hist.UndoCount());
-            Assert.AreEqual(2, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(1));
+            Assert.That(hist.UndoCount(), Is.EqualTo(2));
+            Assert.That(hist.RedoCount(), Is.EqualTo(2));
             // The current situation is a follows: the UndoStack consists of an
             // Increment with no effect and one completed Increment. The RedoStack
             // has a completed Increment and a completed Decrement.
@@ -706,13 +713,13 @@ namespace SEE.Utils.History
             // The completed Increment is moved from the RedoStack to the UndoStack.
             // Because that Increment is completed, a new instance of Increment
             // with progress state NoEffect will be added to the UndoStack.
-            Assert.AreEqual(2, Counter.Value);
-            Assert.AreEqual(3, hist.UndoCount());
-            Assert.AreEqual(1, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(2));
+            Assert.That(hist.UndoCount(), Is.EqualTo(3));
+            Assert.That(hist.RedoCount(), Is.EqualTo(1));
             hist.Redo(); // re-doing a Decrement
-            Assert.AreEqual(1, Counter.Value);
-            Assert.AreEqual(4, hist.UndoCount());
-            Assert.AreEqual(0, hist.RedoCount());
+            Assert.That(Counter.Value, Is.EqualTo(1));
+            Assert.That(hist.UndoCount(), Is.EqualTo(4));
+            Assert.That(hist.RedoCount(), Is.EqualTo(0));
         }
     }
 }

--- a/Assets/SEETests/TestActionStateType.cs
+++ b/Assets/SEETests/TestActionStateType.cs
@@ -119,7 +119,11 @@ namespace SEE.Controls.Actions
         public void TestEquality(AbstractActionStateType type)
         {
             Assert.That(type, Is.Not.Null, "Type must not be null.");
+            // We redefined `Equals`. The purpose of this test is to check
+            // whether the redefinition yields true when comparing the type with itself.
             Assert.That(type.Equals(type), Is.True, $"{type.Name} must be equal to itself.");
+            // We redefined `Equals`. The purpose of this test is to check whether
+            // the redefinition yields true when comparing against null.
             Assert.That(type.Equals(null), Is.False, $"{type.Name} must not be equal to null.");
             Assert.That(allRootTypes.AllElements().Where(type.Equals).Count(), Is.EqualTo(1),
                         "An ActionStateType must only be equal to itself!");

--- a/Assets/SEETests/TestActionStateType.cs
+++ b/Assets/SEETests/TestActionStateType.cs
@@ -123,7 +123,7 @@ namespace SEE.Controls.Actions
             // whether the redefinition yields true when comparing the type with itself.
             Assert.That(type.Equals(type), Is.True, $"{type.Name} must be equal to itself.");
             // We redefined `Equals`. The purpose of this test is to check whether
-            // the redefinition yields true when comparing against null.
+            // the redefinition yields false when comparing against null.
             Assert.That(type.Equals(null), Is.False, $"{type.Name} must not be equal to null.");
             Assert.That(allRootTypes.AllElements().Where(type.Equals).Count(), Is.EqualTo(1),
                         "An ActionStateType must only be equal to itself!");

--- a/Assets/SEETests/TestActionStateType.cs
+++ b/Assets/SEETests/TestActionStateType.cs
@@ -118,6 +118,7 @@ namespace SEE.Controls.Actions
         [Test, TestCaseSource(nameof(AllTypeSupplier))]
         public void TestEquality(AbstractActionStateType type)
         {
+            Assert.That(type, Is.Not.Null, "Type must not be null.");
             Assert.That(type.Equals(type), Is.True, $"{type.Name} must be equal to itself.");
             Assert.That(type.Equals(null), Is.False, $"{type.Name} must not be equal to null.");
             Assert.That(allRootTypes.AllElements().Where(type.Equals).Count(), Is.EqualTo(1),

--- a/Assets/SEETests/TestActionStateType.cs
+++ b/Assets/SEETests/TestActionStateType.cs
@@ -49,11 +49,11 @@ namespace SEE.Controls.Actions
         [Test]
         public void AllActionsPresent()
         {
-            Assert.AreEqual(GetAllTypes(), allRootTypes.AllElements(),
-                            "ActionStateTypes.AllRootTypes.AllElements() must contain all action types and only those!\n"
-                            + " And the order must be preserved.\n"
-                            + DumpDiff(GetAllTypes(), allRootTypes.AllElements())
-                            + "\n");
+            Assert.That(allRootTypes.AllElements(), Is.EqualTo(GetAllTypes()),
+                        "ActionStateTypes.AllRootTypes.AllElements() must contain all action types and only those!\n"
+                        + " And the order must be preserved.\n"
+                        + DumpDiff(GetAllTypes(), allRootTypes.AllElements())
+                        + "\n");
         }
 
         private string DumpDiff(List<AbstractActionStateType> expected, IList<AbstractActionStateType> actual)
@@ -88,23 +88,26 @@ namespace SEE.Controls.Actions
         [Test]
         public void ActionStateTypesAllRootTypesJustContainsAllRoots()
         {
-            Assert.AreEqual(GetAllRootTypes(), allRootTypes.ToList(),
-                            "ActionStateTypes.AllRootTypes must contain all of its root types and only those!"
-                            + " And the order must be preserved.");
+            Assert.That(allRootTypes.ToList(), Is.EqualTo(GetAllRootTypes()),
+                        "ActionStateTypes.AllRootTypes must contain all of its root types and only those!"
+                        + " And the order must be preserved.");
         }
 
         [Test]
         public void TestNoAttributeNull()
         {
-            Assert.IsEmpty(allRootTypes.AllElements().Where(x => x.Description == null || x.Name == null || x.Icon == default),
-                "No attribute of an AbstractActionStateType may be null or default!");
+            Assert.That(allRootTypes.AllElements()
+                                    .Where(x => x.Description == null || x.Name == null || x.Icon == default),
+                        Is.Empty,
+                        "No attribute of an AbstractActionStateType may be null or default!");
         }
 
         [Test]
         public void TestNameUnique()
         {
-            Assert.AreEqual(allRootTypes.AllElements().Count, allRootTypes.AllElements().Select(x => x.Name).Distinct().Count(),
-                            "Names of AbstractActionStateType must be unique!");
+            Assert.That(allRootTypes.AllElements().Select(x => x.Name).Distinct().Count(),
+                        Is.EqualTo(allRootTypes.AllElements().Count),
+                        "Names of AbstractActionStateType must be unique!");
         }
 
         public static IEnumerable<TestCaseData> AllTypeSupplier()
@@ -115,10 +118,10 @@ namespace SEE.Controls.Actions
         [Test, TestCaseSource(nameof(AllTypeSupplier))]
         public void TestEquality(AbstractActionStateType type)
         {
-            Assert.IsTrue(type.Equals(type));
-            Assert.IsFalse(type.Equals(null));
-            Assert.AreEqual(1, allRootTypes.AllElements().Where(type.Equals).Count(),
-                            "An ActionStateType must only be equal to itself!");
+            Assert.That(type.Equals(type), Is.True, $"{type.Name} must be equal to itself.");
+            Assert.That(type.Equals(null), Is.False, $"{type.Name} must not be equal to null.");
+            Assert.That(allRootTypes.AllElements().Where(type.Equals).Count(), Is.EqualTo(1),
+                        "An ActionStateType must only be equal to itself!");
         }
     }
 }

--- a/Assets/SEETests/TestConfigIO.cs
+++ b/Assets/SEETests/TestConfigIO.cs
@@ -22,7 +22,7 @@ namespace SEE.Utils
             {
                 { "label", 0 }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : 0;\n"));
+            Assert.That(ConfigReader.Parse("label : 0;\n"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace SEE.Utils
             {
                 { "l", -1 }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("l : -1;"));
+            Assert.That(ConfigReader.Parse("l : -1;"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace SEE.Utils
             {
                 { "label", 123 }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : +123;"));
+            Assert.That(ConfigReader.Parse("label : +123;"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace SEE.Utils
             {
                 { "label", 123.0f }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label: +123.0;"));
+            Assert.That(ConfigReader.Parse("label: +123.0;"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace SEE.Utils
             {
                 { "label", -1234.0f }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : -1,234.00;"));
+            Assert.That(ConfigReader.Parse("label : -1,234.00;"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace SEE.Utils
             {
                 { "label", 1.234567E-06f }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : 1.234567E-06 ;"));
+            Assert.That(ConfigReader.Parse("label : 1.234567E-06 ;"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace SEE.Utils
             {
                 { "label", -1.234567e-1f }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label\t: -1.234567e-1;\r"));
+            Assert.That(ConfigReader.Parse("label\t: -1.234567e-1;\r"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace SEE.Utils
             {
                 { "label", value }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse($"label\t: {value.ToString("F8", System.Globalization.CultureInfo.InvariantCulture)};\r"));
+            Assert.That(ConfigReader.Parse($"label\t: {value.ToString("F8", System.Globalization.CultureInfo.InvariantCulture)};\r"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace SEE.Utils
             {
                 { "label", value }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse($"label\t: {value.ToString("F8", System.Globalization.CultureInfo.InvariantCulture)};\r"));
+            Assert.That(ConfigReader.Parse($"label\t: {value.ToString("F8", System.Globalization.CultureInfo.InvariantCulture)};\r"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace SEE.Utils
             {
                 { "label", "hello" }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : \"hello\";"));
+            Assert.That(ConfigReader.Parse("label : \"hello\";"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace SEE.Utils
             {
                 { "label", "" }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : \"\";"));
+            Assert.That(ConfigReader.Parse("label : \"\";"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace SEE.Utils
             {
                 { "label", "\"" }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : \"\"\"\";"));
+            Assert.That(ConfigReader.Parse("label : \"\"\"\";"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace SEE.Utils
             {
                 { "label", "\"hello, world\"" }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : \"\"\"hello, world\"\"\";"));
+            Assert.That(ConfigReader.Parse("label : \"\"\"hello, world\"\"\";"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace SEE.Utils
             {
                 { "label", true }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : true;"));
+            Assert.That(ConfigReader.Parse("label : true;"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace SEE.Utils
             {
                 { "label", false }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("label : false;"));
+            Assert.That(ConfigReader.Parse("label : false;"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace SEE.Utils
             {
                 { "attr", new Dictionary<string, object>() { { "int", 1 } } }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("attr : { int: 1; };"));
+            Assert.That(ConfigReader.Parse("attr : { int: 1; };"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace SEE.Utils
                 { "attr", new Dictionary<string, object>() }
             };
             Dictionary<string, object> actual = ConfigReader.Parse("attr : { };");
-            CollectionAssert.AreEquivalent(expected, actual);
+            Assert.That(actual, Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace SEE.Utils
             {
                 { "attr", new Dictionary<string, object>() { { "int", 1 }, { "x", "hello" } } }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("attr : { int: 1; x : \"hello\"; };"));
+            Assert.That(ConfigReader.Parse("attr : { int: 1; x : \"hello\"; };"), Is.EquivalentTo(expected));
         }
 
 
@@ -206,7 +206,7 @@ namespace SEE.Utils
             {
                 { "attr", new Dictionary<string, object>() { { "x", new Dictionary<string, object>() } } }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("attr : { x: {}; };"));
+            Assert.That(ConfigReader.Parse("attr : { x: {}; };"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -216,7 +216,7 @@ namespace SEE.Utils
             {
                 { "attr", new Dictionary<string, object>() { { "a", 1 }, { "b", 2 }, { "x", new Dictionary<string, object>() { { "y", true }, { "z", false } } } } }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("attr : { a: 1; b: 2; x: {y : true; z : false;}; };"));
+            Assert.That(ConfigReader.Parse("attr : { a: 1; b: 2; x: {y : true; z : false;}; };"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -226,7 +226,7 @@ namespace SEE.Utils
             {
                 { "list", new List<object>() { } }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("list : [];"));
+            Assert.That(ConfigReader.Parse("list : [];"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -236,7 +236,7 @@ namespace SEE.Utils
             {
                 { "list", new List<object>() { 1, 2, 3 } }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("list : [ 1; 2; 3;];"));
+            Assert.That(ConfigReader.Parse("list : [ 1; 2; 3;];"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -246,7 +246,7 @@ namespace SEE.Utils
             {
                 { "list", new List<object>() { true} }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("list : [ true; ];"));
+            Assert.That(ConfigReader.Parse("list : [ true; ];"), Is.EquivalentTo(expected));
         }
 
         [Test]
@@ -256,7 +256,7 @@ namespace SEE.Utils
             {
                 { "list", new List<object>() { new List<object>(), new List<object>() { 1 }, new List<object>() { 1, 2 } } }
             };
-            CollectionAssert.AreEquivalent(expected, ConfigReader.Parse("list : [ []; [1;]; [1; 2;];];"));
+            Assert.That(ConfigReader.Parse("list : [ []; [1;]; [1; 2;];];"), Is.EquivalentTo(expected));
         }
 
         /// <summary>
@@ -363,10 +363,10 @@ namespace SEE.Utils
 
         private void AreEqualMetricColorMap(ColorMap saved, ColorMap loaded)
         {
-            Assert.AreEqual(saved.Count, loaded.Count);
+            Assert.That(loaded.Count, Is.EqualTo(saved.Count));
             foreach (var entry in saved)
             {
-                Assert.AreEqual(entry.Value, loaded[entry.Key]);
+                Assert.That(loaded[entry.Key], Is.EqualTo(entry.Value));
             }
         }
 
@@ -566,8 +566,8 @@ namespace SEE.Utils
         {
             SEECityAttributesAreEqual(expected, actual);
             AreEqual(expected.VCSPath, actual.VCSPath);
-            Assert.AreEqual(expected.OldRevision, actual.OldRevision);
-            Assert.AreEqual(expected.NewRevision, actual.NewRevision);
+            Assert.That(actual.OldRevision, Is.EqualTo(expected.OldRevision));
+            Assert.That(actual.NewRevision, Is.EqualTo(expected.NewRevision));
         }
 
         /// <summary>
@@ -592,7 +592,7 @@ namespace SEE.Utils
         /// <param name="actual">actual list</param>
         private static void AreEqual(IList<RandomAttributeDescriptor> expected, IList<RandomAttributeDescriptor> actual)
         {
-            Assert.AreEqual(expected.Count, actual.Count);
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
             foreach (RandomAttributeDescriptor outer in expected)
             {
                 bool found = false;
@@ -600,10 +600,10 @@ namespace SEE.Utils
                 {
                     if (outer.Name == inner.Name)
                     {
-                        Assert.AreEqual(outer.Mean, inner.Mean);
-                        Assert.AreEqual(outer.StandardDeviation, inner.StandardDeviation);
-                        Assert.AreEqual(outer.Minimum, inner.Minimum);
-                        Assert.AreEqual(outer.Maximum, inner.Maximum);
+                        Assert.That(inner.Mean, Is.EqualTo(outer.Mean));
+                        Assert.That(inner.StandardDeviation, Is.EqualTo(outer.StandardDeviation));
+                        Assert.That(inner.Minimum, Is.EqualTo(outer.Minimum));
+                        Assert.That(inner.Maximum, Is.EqualTo(outer.Maximum));
                         found = true;
                         break;
                     }
@@ -623,10 +623,10 @@ namespace SEE.Utils
         /// <param name="actual">actual constraint</param>
         private static void AreEqual(Constraint expected, Constraint actual)
         {
-            Assert.AreEqual(expected.NodeType, actual.NodeType);
-            Assert.AreEqual(expected.EdgeType, actual.EdgeType);
-            Assert.AreEqual(expected.NodeNumber, actual.NodeNumber);
-            Assert.AreEqual(expected.EdgeDensity, actual.EdgeDensity);
+            Assert.That(actual.NodeType, Is.EqualTo(expected.NodeType));
+            Assert.That(actual.EdgeType, Is.EqualTo(expected.EdgeType));
+            Assert.That(actual.NodeNumber, Is.EqualTo(expected.NodeNumber));
+            Assert.That(actual.EdgeDensity, Is.EqualTo(expected.EdgeDensity));
         }
 
         /// <summary>
@@ -650,7 +650,7 @@ namespace SEE.Utils
         private static void AbstractSEECityAttributesAreEqual(AbstractSEECity expected, AbstractSEECity actual)
         {
             AreEqualSharedAttributes(expected, actual);
-            Assert.AreEqual(expected.NodeTypes.Count, actual.NodeTypes.Count);
+            Assert.That(actual.NodeTypes.Count, Is.EqualTo(expected.NodeTypes.Count));
             AreEqualNodeTypes(expected, actual);
             AreEqualMetricToColor(expected, actual);
             AreEqualNodeLayoutSettings(expected.NodeLayoutSettings, actual.NodeLayoutSettings);
@@ -670,12 +670,12 @@ namespace SEE.Utils
         /// <param name="actual">actual tooltip settings</param>
         private static void AreEqual(TooltipSettings expected, TooltipSettings actual)
         {
-            Assert.AreEqual(expected.ShowName, actual.ShowName);
-            Assert.AreEqual(expected.ShowType, actual.ShowType);
-            Assert.AreEqual(expected.ShowIncomingEdges, actual.ShowIncomingEdges);
-            Assert.AreEqual(expected.ShowOutgoingEdges, actual.ShowOutgoingEdges);
-            Assert.AreEqual(expected.ShowNodeKind, actual.ShowNodeKind);
-            Assert.AreEqual(expected.ShownMetrics, actual.ShownMetrics);
+            Assert.That(actual.ShowName, Is.EqualTo(expected.ShowName));
+            Assert.That(actual.ShowType, Is.EqualTo(expected.ShowType));
+            Assert.That(actual.ShowIncomingEdges, Is.EqualTo(expected.ShowIncomingEdges));
+            Assert.That(actual.ShowOutgoingEdges, Is.EqualTo(expected.ShowOutgoingEdges));
+            Assert.That(actual.ShowNodeKind, Is.EqualTo(expected.ShowNodeKind));
+            Assert.That(actual.ShownMetrics, Is.EqualTo(expected.ShownMetrics));
         }
 
         /// <summary>
@@ -685,8 +685,8 @@ namespace SEE.Utils
         /// <param name="actual">actual values</param>
         private static void AreEqual(MarkerAttributes expected, MarkerAttributes actual)
         {
-            Assert.AreEqual(expected.MarkerHeight, actual.MarkerHeight);
-            Assert.AreEqual(expected.MarkerWidth, actual.MarkerWidth);
+            Assert.That(actual.MarkerHeight, Is.EqualTo(expected.MarkerHeight));
+            Assert.That(actual.MarkerWidth, Is.EqualTo(expected.MarkerWidth));
             AreEqual(expected.AdditionBeamColor, actual.AdditionBeamColor);
             AreEqual(expected.ChangeBeamColor, actual.ChangeBeamColor);
             AreEqual(expected.DeletionBeamColor, actual.DeletionBeamColor);
@@ -700,7 +700,7 @@ namespace SEE.Utils
         /// <param name="actual">actual value</param>
         private static void AreEqualMetricToColor(AbstractSEECity expected, AbstractSEECity actual)
         {
-            Assert.AreEqual(expected.MetricToColor.Count, actual.MetricToColor.Count);
+            Assert.That(actual.MetricToColor.Count, Is.EqualTo(expected.MetricToColor.Count));
             foreach (var entry in expected.MetricToColor)
             {
                 ColorRange actualColorRange = actual.MetricToColor[entry.Key];
@@ -718,7 +718,8 @@ namespace SEE.Utils
         {
             foreach (var entry in expected.NodeTypes)
             {
-                Assert.IsTrue(actual.NodeTypes.TryGetValue(entry.Key, out VisualNodeAttributes actualSetting));
+                Assert.That(actual.NodeTypes.TryGetValue(entry.Key, out VisualNodeAttributes actualSetting),
+                            Is.True, $"There is no node type {entry.Key} in the actual settings.");
                 AreEqualNodeSettings(entry.Value, actualSetting);
             }
         }
@@ -731,12 +732,12 @@ namespace SEE.Utils
         /// <param name="actual">actual label setting</param>
         private static void AreEqual(LabelAttributes expected, LabelAttributes actual)
         {
-            Assert.AreEqual(expected.Show, actual.Show);
-            Assert.AreEqual(expected.Distance, actual.Distance, 0.001f);
-            Assert.AreEqual(expected.FontSize, actual.FontSize, 0.001f);
+            Assert.That(actual.Show, Is.EqualTo(expected.Show));
+            Assert.That(actual.Distance, Is.EqualTo(expected.Distance).Within(0.001f));
+            Assert.That(actual.FontSize, Is.EqualTo(expected.FontSize).Within(0.001f));
             AreEqual(expected.FontColor, actual.FontColor);
-            Assert.AreEqual(expected.AnimationFactor, actual.AnimationFactor, 0.001f);
-            Assert.AreEqual(expected.LabelAlpha, actual.LabelAlpha, 0.001f);
+            Assert.That(actual.AnimationFactor, Is.EqualTo(expected.AnimationFactor).Within(0.001f));
+            Assert.That(actual.LabelAlpha, Is.EqualTo(expected.LabelAlpha).Within(0.001f));
         }
 
         /// <summary>
@@ -749,7 +750,7 @@ namespace SEE.Utils
         {
             AreEqual(expected.Lower, actual.Lower);
             AreEqual(expected.Upper, actual.Upper);
-            Assert.AreEqual(expected.NumberOfColors, actual.NumberOfColors);
+            Assert.That(actual.NumberOfColors, Is.EqualTo(expected.NumberOfColors));
         }
 
         /// <summary>
@@ -760,10 +761,10 @@ namespace SEE.Utils
         /// <param name="actual">actual color</param>
         private static void AreEqual(Color expected, Color actual)
         {
-            Assert.AreEqual(expected.r, actual.r, 0.001f);
-            Assert.AreEqual(expected.g, actual.g, 0.001f);
-            Assert.AreEqual(expected.b, actual.b, 0.001f);
-            Assert.AreEqual(expected.a, actual.a, 0.001f);
+            Assert.That(actual.r, Is.EqualTo(expected.r).Within(0.001f));
+            Assert.That(actual.g, Is.EqualTo(expected.g).Within(0.001f));
+            Assert.That(actual.b, Is.EqualTo(expected.b).Within(0.001f));
+            Assert.That(actual.a, Is.EqualTo(expected.a).Within(0.001f));
         }
 
         //--------------------------------------------------------
@@ -920,30 +921,30 @@ namespace SEE.Utils
 
         private static void AreEqualErosionSettings(ErosionAttributes expected, ErosionAttributes actual)
         {
-            Assert.AreEqual(expected.ShowInnerErosions, actual.ShowInnerErosions);
-            Assert.AreEqual(expected.ShowLeafErosions, actual.ShowLeafErosions);
-            Assert.AreEqual(expected.ShowDashboardIssuesInCodeWindow, actual.ShowDashboardIssuesInCodeWindow);
-            Assert.AreEqual(expected.ErosionScalingFactor, actual.ErosionScalingFactor);
+            Assert.That(actual.ShowInnerErosions, Is.EqualTo(expected.ShowInnerErosions));
+            Assert.That(actual.ShowLeafErosions, Is.EqualTo(expected.ShowLeafErosions));
+            Assert.That(actual.ShowDashboardIssuesInCodeWindow, Is.EqualTo(expected.ShowDashboardIssuesInCodeWindow));
+            Assert.That(actual.ErosionScalingFactor, Is.EqualTo(expected.ErosionScalingFactor));
 
-            Assert.AreEqual(expected.StyleIssue, actual.StyleIssue);
-            Assert.AreEqual(expected.UniversalIssue, actual.UniversalIssue);
-            Assert.AreEqual(expected.MetricIssue, actual.MetricIssue);
-            Assert.AreEqual(expected.DeadCodeIssue, actual.DeadCodeIssue);
-            Assert.AreEqual(expected.CycleIssue, actual.CycleIssue);
-            Assert.AreEqual(expected.CloneIssue, actual.CloneIssue);
-            Assert.AreEqual(expected.ArchitectureIssue, actual.ArchitectureIssue);
-            Assert.AreEqual(expected.LspHint, actual.LspHint);
-            Assert.AreEqual(expected.LspInfo, actual.LspInfo);
-            Assert.AreEqual(expected.LspWarning, actual.LspWarning);
-            Assert.AreEqual(expected.LspError, actual.LspError);
+            Assert.That(actual.StyleIssue, Is.EqualTo(expected.StyleIssue));
+            Assert.That(actual.UniversalIssue, Is.EqualTo(expected.UniversalIssue));
+            Assert.That(actual.MetricIssue, Is.EqualTo(expected.MetricIssue));
+            Assert.That(actual.DeadCodeIssue, Is.EqualTo(expected.DeadCodeIssue));
+            Assert.That(actual.CycleIssue, Is.EqualTo(expected.CycleIssue));
+            Assert.That(actual.CloneIssue, Is.EqualTo(expected.CloneIssue));
+            Assert.That(actual.ArchitectureIssue, Is.EqualTo(expected.ArchitectureIssue));
+            Assert.That(actual.LspHint, Is.EqualTo(expected.LspHint));
+            Assert.That(actual.LspInfo, Is.EqualTo(expected.LspInfo));
+            Assert.That(actual.LspWarning, Is.EqualTo(expected.LspWarning));
+            Assert.That(actual.LspError, Is.EqualTo(expected.LspError));
 
-            Assert.AreEqual(expected.StyleIssueSum, actual.StyleIssueSum);
-            Assert.AreEqual(expected.UniversalIssueSum, actual.UniversalIssueSum);
-            Assert.AreEqual(expected.MetricIssueSum, actual.MetricIssueSum);
-            Assert.AreEqual(expected.DeadCodeIssueSum, actual.DeadCodeIssueSum);
-            Assert.AreEqual(expected.CycleIssueSum, actual.CycleIssueSum);
-            Assert.AreEqual(expected.CloneIssueSum, actual.CloneIssueSum);
-            Assert.AreEqual(expected.ArchitectureIssueSum, actual.ArchitectureIssueSum);
+            Assert.That(actual.StyleIssueSum, Is.EqualTo(expected.StyleIssueSum));
+            Assert.That(actual.UniversalIssueSum, Is.EqualTo(expected.UniversalIssueSum));
+            Assert.That(actual.MetricIssueSum, Is.EqualTo(expected.MetricIssueSum));
+            Assert.That(actual.DeadCodeIssueSum, Is.EqualTo(expected.DeadCodeIssueSum));
+            Assert.That(actual.CycleIssueSum, Is.EqualTo(expected.CycleIssueSum));
+            Assert.That(actual.CloneIssueSum, Is.EqualTo(expected.CloneIssueSum));
+            Assert.That(actual.ArchitectureIssueSum, Is.EqualTo(expected.ArchitectureIssueSum));
         }
 
         private static void WipeOutEdgeLayoutSettings(AbstractSEECity city)
@@ -968,22 +969,22 @@ namespace SEE.Utils
 
         private static void AreEqualEdgeLayoutSettings(EdgeLayoutAttributes expected, EdgeLayoutAttributes actual)
         {
-            Assert.AreEqual(expected.Kind, actual.Kind);
-            Assert.AreEqual(expected.ShowEdges, actual.ShowEdges);
-            Assert.AreEqual(expected.AnimateEdgeFlow, actual.AnimateEdgeFlow);
-            Assert.AreEqual(expected.AnimationKind, actual.AnimationKind);
-            Assert.AreEqual(expected.AnimateTransitiveSourceEdges, actual.AnimateTransitiveSourceEdges);
-            Assert.AreEqual(expected.AnimateTransitiveTargetEdges, actual.AnimateTransitiveTargetEdges);
-            Assert.AreEqual(expected.EdgeWidth, actual.EdgeWidth);
-            Assert.AreEqual(expected.Tension, actual.Tension);
+            Assert.That(actual.Kind, Is.EqualTo(expected.Kind));
+            Assert.That(actual.ShowEdges, Is.EqualTo(expected.ShowEdges));
+            Assert.That(actual.AnimateEdgeFlow, Is.EqualTo(expected.AnimateEdgeFlow));
+            Assert.That(actual.AnimationKind, Is.EqualTo(expected.AnimationKind));
+            Assert.That(actual.AnimateTransitiveSourceEdges, Is.EqualTo(expected.AnimateTransitiveSourceEdges));
+            Assert.That(actual.AnimateTransitiveTargetEdges, Is.EqualTo(expected.AnimateTransitiveTargetEdges));
+            Assert.That(actual.EdgeWidth, Is.EqualTo(expected.EdgeWidth));
+            Assert.That(actual.Tension, Is.EqualTo(expected.Tension));
         }
 
         private static void AreEqualEdgeSelectionSettings(EdgeSelectionAttributes expected, EdgeSelectionAttributes actual)
         {
-            Assert.AreEqual(expected.TubularSegments, actual.TubularSegments);
-            Assert.AreEqual(expected.Radius, actual.Radius);
-            Assert.AreEqual(expected.RadialSegments, actual.RadialSegments);
-            Assert.AreEqual(expected.AreSelectable, actual.AreSelectable);
+            Assert.That(actual.TubularSegments, Is.EqualTo(expected.TubularSegments));
+            Assert.That(actual.Radius, Is.EqualTo(expected.Radius));
+            Assert.That(actual.RadialSegments, Is.EqualTo(expected.RadialSegments));
+            Assert.That(actual.AreSelectable, Is.EqualTo(expected.AreSelectable));
         }
 
         private static void WipeOutNodeLayoutSettings(AbstractSEECity city)
@@ -994,7 +995,7 @@ namespace SEE.Utils
 
         private static void AreEqualNodeLayoutSettings(NodeLayoutAttributes expected, NodeLayoutAttributes actual)
         {
-            Assert.AreEqual(expected.Kind, actual.Kind);
+            Assert.That(actual.Kind, Is.EqualTo(expected.Kind));
             AreEqual(expected.LayoutPath, actual.LayoutPath);
         }
 
@@ -1013,23 +1014,23 @@ namespace SEE.Utils
 
         private static void AreEqualNodeSettings(VisualNodeAttributes expected, VisualNodeAttributes actual)
         {
-            Assert.AreEqual(expected.Shape, actual.Shape);
-            Assert.AreEqual(expected.IsRelevant, actual.IsRelevant);
+            Assert.That(actual.Shape, Is.EqualTo(expected.Shape));
+            Assert.That(actual.IsRelevant, Is.EqualTo(expected.IsRelevant));
             AreEqual(expected.MetricToLength, actual.MetricToLength);
-            Assert.AreEqual(expected.ColorProperty.ColorMetric, actual.ColorProperty.ColorMetric);
-            Assert.AreEqual(expected.MinimalBlockLength, actual.MinimalBlockLength);
-            Assert.AreEqual(expected.MaximalBlockLength, actual.MaximalBlockLength);
-            Assert.AreEqual(expected.OutlineWidth, actual.OutlineWidth);
+            Assert.That(actual.ColorProperty.ColorMetric, Is.EqualTo(expected.ColorProperty.ColorMetric));
+            Assert.That(actual.MinimalBlockLength, Is.EqualTo(expected.MinimalBlockLength));
+            Assert.That(actual.MaximalBlockLength, Is.EqualTo(expected.MaximalBlockLength));
+            Assert.That(actual.OutlineWidth, Is.EqualTo(expected.OutlineWidth));
             AreEqualAntennaSettings(expected.AntennaSettings, actual.AntennaSettings);
-            Assert.AreEqual(expected.ShowNames, actual.ShowNames);
+            Assert.That(actual.ShowNames, Is.EqualTo(expected.ShowNames));
         }
 
         private static void AreEqual(IList<string> expected, IList<string> actual)
         {
-            Assert.AreEqual(expected.Count, actual.Count);
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
             for (int i = 0; i < expected.Count; i++)
             {
-                Assert.AreEqual(expected[i], actual[i]);
+                Assert.That(actual[i], Is.EqualTo(expected[i]));
             }
         }
 
@@ -1040,10 +1041,10 @@ namespace SEE.Utils
 
         private static void AreEqualAntennaSettings(AntennaAttributes expected, AntennaAttributes actual)
         {
-            Assert.AreEqual(expected.AntennaSections.Count, actual.AntennaSections.Count);
+            Assert.That(actual.AntennaSections.Count, Is.EqualTo(expected.AntennaSections.Count));
             for (int i = 0; i < expected.AntennaSections.Count; i++)
             {
-                Assert.AreEqual(expected.AntennaSections[i], actual.AntennaSections[i]);
+                Assert.That(actual.AntennaSections[i], Is.EqualTo(expected.AntennaSections[i]));
             }
         }
 
@@ -1061,19 +1062,19 @@ namespace SEE.Utils
 
         private static void AreEqualSharedAttributes(AbstractSEECity expected, AbstractSEECity actual)
         {
-            Assert.AreEqual(expected.LODCulling, actual.LODCulling);
-            CollectionAssert.AreEquivalent(expected.HierarchicalEdges, actual.HierarchicalEdges);
+            Assert.That(actual.LODCulling, Is.EqualTo(expected.LODCulling));
+            Assert.That(actual.HierarchicalEdges, Is.EquivalentTo(expected.HierarchicalEdges));
             AreEquivalent(expected.NodeTypes, actual.NodeTypes);
             AreEqual(expected.ConfigurationPath, actual.ConfigurationPath);
             AreEqual(expected.SourceCodeDirectory, actual.SourceCodeDirectory);
             AreEqual(expected.SolutionPath, actual.SolutionPath);
-            Assert.AreEqual(expected.ZScoreScale, actual.ZScoreScale);
-            Assert.AreEqual(expected.ScaleOnlyLeafMetrics, actual.ScaleOnlyLeafMetrics);
+            Assert.That(actual.ZScoreScale, Is.EqualTo(expected.ZScoreScale));
+            Assert.That(actual.ScaleOnlyLeafMetrics, Is.EqualTo(expected.ScaleOnlyLeafMetrics));
         }
 
         private static void AreEquivalent(NodeTypeVisualsMap expected, NodeTypeVisualsMap actual)
         {
-            Assert.AreEqual(expected.Count, actual.Count);
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
             foreach (var entry in expected)
             {
                 if (actual.TryGetValue(entry.Key, out VisualNodeAttributes entryInActual))

--- a/Assets/SEETests/TestDashboard.cs
+++ b/Assets/SEETests/TestDashboard.cs
@@ -52,32 +52,32 @@ namespace SEE.Net.Dashboard
         public IEnumerator TestDashboardVersionCorrect() => UniTask.ToCoroutine(async () =>
         {
             DashboardVersion version = await DashboardRetriever.Instance.GetDashboardVersionAsync();
-            Assert.AreEqual(DashboardVersion.SupportedVersion.MajorVersion, version.MajorVersion);
-            Assert.AreEqual(DashboardVersion.SupportedVersion.MinorVersion, version.MinorVersion);
+            Assert.That(version.MajorVersion, Is.EqualTo(DashboardVersion.SupportedVersion.MajorVersion));
+            Assert.That(version.MinorVersion, Is.EqualTo(DashboardVersion.SupportedVersion.MinorVersion));
         });
 
         [UnityTest]
         public IEnumerator TestDashboardSystemEntity() => UniTask.ToCoroutine(async () =>
         {
             EntityList list = await DashboardRetriever.Instance.GetSystemEntityAsync("latest");
-            Assert.IsNotNull(list);
-            Assert.AreEqual(1, list.Entities.Count);
+            Assert.That(list, Is.Not.Null, "The system entity list must have been retrieved.");
+            Assert.That(list.Entities.Count, Is.EqualTo(1));
         });
 
         [UnityTest]
         public IEnumerator TestDashboardEntities() => UniTask.ToCoroutine(async () =>
         {
             EntityList list = await DashboardRetriever.Instance.GetEntitiesAsync("latest");
-            Assert.IsNotNull(list);
-            Assert.IsNotEmpty(list.Entities);
+            Assert.That(list, Is.Not.Null, "The entity list must have been retrieved.");
+            Assert.That(list.Entities, Is.Not.Empty);
         });
 
         [UnityTest]
         public IEnumerator TestDashboardMetrics() => UniTask.ToCoroutine(async () =>
         {
             MetricList list = await DashboardRetriever.Instance.GetMetricsAsync("latest");
-            Assert.IsNotNull(list);
-            Assert.IsNotEmpty(list.Metrics);
+            Assert.That(list, Is.Not.Null, "The metric list must have been retrieved.");
+            Assert.That(list.Metrics, Is.Not.Empty);
         });
 
         [UnityTest]
@@ -86,33 +86,34 @@ namespace SEE.Net.Dashboard
             const string entity = "81"; // This entity does not exist.
             const string metric = SEE.DataModel.DG.Metrics.Prefix + "LOC";
             MetricValueRange range = await DashboardRetriever.Instance.GetMetricValueRangeAsync(entity, metric);
-            Assert.IsNotNull(range);
-            Assert.IsNotEmpty(range.Values);
-            Assert.AreEqual(range.Entity, entity);
-            Assert.AreEqual(range.Metric, metric);
-            Assert.IsTrue(range.Values.Contains(null));
+            Assert.That(range, Is.Not.Null, "The metric value range must have been retrieved.");
+            Assert.That(range.Values, Is.Not.Empty);
+            Assert.That(range.Entity, Is.EqualTo(entity));
+            Assert.That(range.Metric, Is.EqualTo(metric));
+            // The entity does not exist, hence there is no value for it.
+            Assert.That(range.Values, Has.Member(null));
         });
 
         [UnityTest]
         public IEnumerator TestDashboardMetricTable() => UniTask.ToCoroutine(async () =>
         {
             MetricValueTable table = await DashboardRetriever.Instance.GetMetricValueTableAsync();
-            Assert.IsNotNull(table);
-            Assert.IsNotEmpty(table.Rows);
+            Assert.That(table, Is.Not.Null, "The metric value table must have been retrieved.");
+            Assert.That(table.Rows, Is.Not.Empty);
         });
 
         [UnityTest]
         public IEnumerator TestDashboardIssueDescription() => UniTask.ToCoroutine(async () =>
         {
             string description = await DashboardRetriever.Instance.GetIssueDescriptionAsync("SV4");
-            Assert.IsNotNull(description);
-            Assert.IsTrue(description.StartsWith("This rule"));
+            Assert.That(description, Is.Not.Null, "The description of issue SV4 must have been retrieved.");
+            Assert.That(description, Does.StartWith("This rule"));
         });
 
         private static IEnumerator TestDashboardIssues<T>() where T : Issue, new() => UniTask.ToCoroutine(async () =>
         {
             IssueTable<T> table = await DashboardRetriever.Instance.GetIssuesAsync<T>();
-            Assert.IsNotNull(table);
+            Assert.That(table, Is.Not.Null, $"The issue table for {typeof(T).Name} must have been retrieved.");
         });
 
         [UnityTest]

--- a/Assets/SEETests/TestDataPath.cs
+++ b/Assets/SEETests/TestDataPath.cs
@@ -30,7 +30,7 @@ namespace SEE.Utils.Paths
                     Root = DataPath.RootKind.Url,
                     Path = $"https://mirror.physik.tu-berlin.de/pub/CTAN/macros/latex/required/psnfss/{filename}"
                 };
-                Assert.AreEqual(DataPath.RootKind.Url, dataPath.Root);
+                Assert.That(dataPath.Root, Is.EqualTo(DataPath.RootKind.Url));
                 using Stream stream = await dataPath.LoadAsync();
                 Debug.Log($"Content length in bytes: {stream.Length}\n");
                 using (FileStream fileStream = File.Create(filename))
@@ -60,7 +60,7 @@ namespace SEE.Utils.Paths
                     Root = DataPath.RootKind.Url,
                     Path = "http://localhost/api/v1/file/client/solution/serverId=&roomPassword=password"
                 };
-                Assert.AreEqual(DataPath.RootKind.Url, dataPath.Root);
+                Assert.That(dataPath.Root, Is.EqualTo(DataPath.RootKind.Url));
                 try
                 {
                     using Stream stream = await dataPath.LoadAsync();
@@ -98,9 +98,9 @@ namespace SEE.Utils.Paths
                     Root = DataPath.RootKind.Absolute,
                     Path = filename
                 };
-                Assert.AreEqual(DataPath.RootKind.Absolute, dataPath.Root);
+                Assert.That(dataPath.Root, Is.EqualTo(DataPath.RootKind.Absolute));
                 using Stream stream = await dataPath.LoadAsync();
-                Assert.AreEqual(content, Read(stream));
+                Assert.That(Read(stream), Is.EqualTo(content), "The loaded content must equal what was written.");
                 FileIO.DeleteIfExists(filename);
             });
 

--- a/Assets/SEETests/TestFilenames.cs
+++ b/Assets/SEETests/TestFilenames.cs
@@ -13,7 +13,7 @@ namespace SEE.Utils
             string pathWithTrailingSeparator = "Assets/SEE/GraphProviders/VCS/";
             string expectedPath = "Assets/SEE/GraphProviders/VCS";
             string trimmedPath = Filenames.TrimEndingDirectorySeparator(pathWithTrailingSeparator, '/');
-            Assert.AreEqual(expectedPath, trimmedPath);
+            Assert.That(trimmedPath, Is.EqualTo(expectedPath));
         }
 
         [Test]
@@ -21,22 +21,22 @@ namespace SEE.Utils
         {
             string path = "X/";
             string trimmedPath = Filenames.TrimEndingDirectorySeparator(path, '/');
-            Assert.AreEqual("X", trimmedPath);
+            Assert.That(trimmedPath, Is.EqualTo("X"));
         }
 
+        /// <summary>
+        /// Tests that a path without a trailing directory separator remains unchanged.
+        /// </summary>
         [Test]
         [TestCase("Assets/SEE/GraphProviders/VCS")]
         [TestCase("Assets/SEE/GraphProviders/VCS/MyFile.cs")]
         [TestCase("MyFile.cs")]
         [TestCase("")]
         [TestCase(null)]
-        /// <summary>
-        /// Tests that a path without a trailing directory separator remains unchanged.
-        /// </summary>
         public void TestTrimEndingDirectorySeparator(string path)
         {
             string trimmedPath = Filenames.TrimEndingDirectorySeparator(path, '/');
-            Assert.AreEqual(path, trimmedPath);
+            Assert.That(trimmedPath, Is.EqualTo(path), "A path without a trailing separator must remain unchanged.");
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace SEE.Utils
         public void TestGetDirectoryName(string path, string expected)
         {
             string directory = Filenames.GetDirectoryName(path, '/');
-            Assert.AreEqual(expected, directory);
+            Assert.That(directory, Is.EqualTo(expected));
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace SEE.Utils
         public void TestGetFilename(string path, string expected)
         {
             string filename = Filenames.Basename(path, '/');
-            Assert.AreEqual(expected, filename);
+            Assert.That(filename, Is.EqualTo(expected));
         }
     }
 }

--- a/Assets/SEETests/TestGit.cs
+++ b/Assets/SEETests/TestGit.cs
@@ -78,8 +78,10 @@ namespace SEE.VCS
 
                 Repository.Clone(TestRepo.Url, localRepoPath, options);
                 // Exists and is not empty.
-                Assert.IsTrue(Directory.Exists(localRepoPath)
-                    && Directory.EnumerateFileSystemEntries(localRepoPath).Any());
+                Assert.That(new DirectoryInfo(localRepoPath), Does.Exist,
+                            $"{localRepoPath} must exist after cloning.");
+                Assert.That(Directory.EnumerateFileSystemEntries(localRepoPath), Is.Not.Empty,
+                            $"{localRepoPath} must not be empty after cloning.");
             }
             catch (LibGit2SharpException)
             {

--- a/Assets/SEETests/TestGitGraphProvider.cs
+++ b/Assets/SEETests/TestGitGraphProvider.cs
@@ -29,6 +29,12 @@ namespace SEE.GraphProviders
         private const string defaultDate = "2024/01/01";
 
         /// <summary>
+        /// The name of the file that most test cases write to and then expect
+        /// as a node in the resulting graph. It is also the node's ID.
+        /// </summary>
+        private const string firstFile = "firstFile.cs";
+
+        /// <summary>
         /// Path to the git directory.
         /// </summary>
         private string gitDirPath;
@@ -151,24 +157,24 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
                 WriteFile("AnotherFile.cs", "This is a test", developerA);
                 WriteFile("AnotherFile.cs", "This is a test", developerB);
 
                 IList<Graph> series = await ProvidingGraphSeriesAsync();
                 Assert.That(series.Count, Is.EqualTo(3));
 
-                Assert.That(series[0].GetNode("firstFile.cs").IntAttributes[NumberOfCommits],
+                Assert.That(series[0].GetNode(firstFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
 
                 Assert.That(series[1].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
-                Assert.That(series[1].GetNode("firstFile.cs").IntAttributes[NumberOfCommits],
+                Assert.That(series[1].GetNode(firstFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
 
                 Assert.That(series[2].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits],
                             Is.EqualTo(2));
-                Assert.That(series[2].GetNode("firstFile.cs").IntAttributes[NumberOfCommits],
+                Assert.That(series[2].GetNode(firstFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
             });
         }
@@ -178,7 +184,7 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
                 WriteFile("AnotherFile.cs", "This is a test", developerA);
                 WriteFile("AnotherFile.cs", "This is a test", developerB);
                 WriteFile(
@@ -188,8 +194,8 @@ namespace SEE.GraphProviders
                 );
 
                 Graph g = await ProvidingGraphAsync();
-                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
-                Node n1 = g.GetNode("firstFile.cs");
+                Assert.That(g.GetNode(firstFile), Is.Not.Null, $"There is no node {firstFile}.");
+                Node n1 = g.GetNode(firstFile);
                 Assert.That(n1.IntAttributes[NumberOfCommits], Is.EqualTo(1));
                 Assert.That(n1.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
 
@@ -208,15 +214,15 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
 
                 Graph g = await ProvidingGraphAsync(date: "2024/12/01");
                 // This file should be too old by now
-                Assert.That(g.GetNode("firstFile.cs").IntAttributes[NumberOfDevelopers], Is.EqualTo(0));
-                Assert.That(g.GetNode("firstFile.cs").IntAttributes[NumberOfCommits], Is.EqualTo(0));
+                Assert.That(g.GetNode(firstFile).IntAttributes[NumberOfDevelopers], Is.EqualTo(0));
+                Assert.That(g.GetNode(firstFile).IntAttributes[NumberOfCommits], Is.EqualTo(0));
                 Graph g2 = await ProvidingGraphAsync();
-                Assert.That(g2.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
-                Node n = g2.GetNode("firstFile.cs");
+                Assert.That(g2.GetNode(firstFile), Is.Not.Null, $"There is no node {firstFile}.");
+                Node n = g2.GetNode(firstFile);
                 Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(1));
                 Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });
@@ -227,14 +233,14 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
-                WriteFile("firstFile.cs", "This is a test from Jan", developerB);
+                WriteFile(firstFile, "This is a test", developerA);
+                WriteFile(firstFile, "This is a test from Jan", developerB);
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
-                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
-                Node n = g.GetNode("firstFile.cs");
+                Assert.That(() => g.GetNode(firstFile), Throws.Nothing);
+                Assert.That(g.GetNode(firstFile), Is.Not.Null, $"There is no node {firstFile}.");
+                Node n = g.GetNode(firstFile);
                 Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
                 Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(2));
             });
@@ -245,9 +251,9 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
                 repo.CreateBranch("newBranch");
-                WriteFile("firstFile.cs", "This is a test on newBranch", developerA);
+                WriteFile(firstFile, "This is a test on newBranch", developerA);
                 Branch branch = repo.Branches["main"] ?? repo.Branches["master"];
                 if (branch == null)
                 {
@@ -259,9 +265,9 @@ namespace SEE.GraphProviders
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
-                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
-                Node n = g.GetNode("firstFile.cs");
+                Assert.That(() => g.GetNode(firstFile), Throws.Nothing);
+                Assert.That(g.GetNode(firstFile), Is.Not.Null, $"There is no node {firstFile}.");
+                Node n = g.GetNode(firstFile);
                 Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
                 Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });
@@ -272,15 +278,15 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
-                WriteFile("firstFile.cs", "This is another test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
+                WriteFile(firstFile, "This is another test", developerA);
                 WriteFile("otherfile.notcs", "This is another test in another file", developerA);
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
-                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
-                Node n = g.GetNode("firstFile.cs");
+                Assert.That(() => g.GetNode(firstFile), Throws.Nothing);
+                Assert.That(g.GetNode(firstFile), Is.Not.Null, $"There is no node {firstFile}.");
+                Node n = g.GetNode(firstFile);
                 Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
                 Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
 
@@ -293,14 +299,14 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
-                WriteFile("firstFile.cs", "This is another test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
+                WriteFile(firstFile, "This is another test", developerA);
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
-                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
-                Node n = g.GetNode("firstFile.cs");
+                Assert.That(() => g.GetNode(firstFile), Throws.Nothing);
+                Assert.That(g.GetNode(firstFile), Is.Not.Null, $"There is no node {firstFile}.");
+                Node n = g.GetNode(firstFile);
                 Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
                 Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });
@@ -311,7 +317,7 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
 
                 Graph g = await ProvidingGraphAsync();
                 Assert.That(g.GetNode("file/does/not/exists"), Is.Null, "There must be no node file/does/not/exists.");
@@ -323,13 +329,13 @@ namespace SEE.GraphProviders
         {
             return UniTask.ToCoroutine(async () =>
             {
-                WriteFile("firstFile.cs", "This is a test", developerA);
+                WriteFile(firstFile, "This is a test", developerA);
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
-                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
-                Node n = g.GetNode("firstFile.cs");
+                Assert.That(() => g.GetNode(firstFile), Throws.Nothing);
+                Assert.That(g.GetNode(firstFile), Is.Not.Null, $"There is no node {firstFile}.");
+                Node n = g.GetNode(firstFile);
                 Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(1));
                 Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });

--- a/Assets/SEETests/TestGitGraphProvider.cs
+++ b/Assets/SEETests/TestGitGraphProvider.cs
@@ -35,6 +35,12 @@ namespace SEE.GraphProviders
         private const string firstFile = "firstFile.cs";
 
         /// <summary>
+        /// The name of a second file used by the test cases that need more than
+        /// one file. It is also the node's ID.
+        /// </summary>
+        private const string anotherFile = "AnotherFile.cs";
+
+        /// <summary>
         /// Path to the git directory.
         /// </summary>
         private string gitDirPath;
@@ -158,8 +164,8 @@ namespace SEE.GraphProviders
             return UniTask.ToCoroutine(async () =>
             {
                 WriteFile(firstFile, "This is a test", developerA);
-                WriteFile("AnotherFile.cs", "This is a test", developerA);
-                WriteFile("AnotherFile.cs", "This is a test", developerB);
+                WriteFile(anotherFile, "This is a test", developerA);
+                WriteFile(anotherFile, "This is a test", developerB);
 
                 IList<Graph> series = await ProvidingGraphSeriesAsync();
                 Assert.That(series.Count, Is.EqualTo(3));
@@ -167,12 +173,12 @@ namespace SEE.GraphProviders
                 Assert.That(series[0].GetNode(firstFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
 
-                Assert.That(series[1].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits],
+                Assert.That(series[1].GetNode(anotherFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
                 Assert.That(series[1].GetNode(firstFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
 
-                Assert.That(series[2].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits],
+                Assert.That(series[2].GetNode(anotherFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(2));
                 Assert.That(series[2].GetNode(firstFile).IntAttributes[NumberOfCommits],
                             Is.EqualTo(1));
@@ -185,8 +191,8 @@ namespace SEE.GraphProviders
             return UniTask.ToCoroutine(async () =>
             {
                 WriteFile(firstFile, "This is a test", developerA);
-                WriteFile("AnotherFile.cs", "This is a test", developerA);
-                WriteFile("AnotherFile.cs", "This is a test", developerB);
+                WriteFile(anotherFile, "This is a test", developerA);
+                WriteFile(anotherFile, "This is a test", developerB);
                 WriteFile(
                     Path.Combine("dir1", "dir2", "actualFile.cs"),
                     "This is a test",
@@ -199,8 +205,8 @@ namespace SEE.GraphProviders
                 Assert.That(n1.IntAttributes[NumberOfCommits], Is.EqualTo(1));
                 Assert.That(n1.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
 
-                Assert.That(g.GetNode("AnotherFile.cs"), Is.Not.Null, "There is no node AnotherFile.cs.");
-                Node n2 = g.GetNode("AnotherFile.cs");
+                Assert.That(g.GetNode(anotherFile), Is.Not.Null, $"There is no node {anotherFile}.");
+                Node n2 = g.GetNode(anotherFile);
                 Assert.That(n2.IntAttributes[NumberOfCommits], Is.EqualTo(2));
                 Assert.That(n2.IntAttributes[NumberOfDevelopers], Is.EqualTo(2));
 

--- a/Assets/SEETests/TestGitGraphProvider.cs
+++ b/Assets/SEETests/TestGitGraphProvider.cs
@@ -156,30 +156,20 @@ namespace SEE.GraphProviders
                 WriteFile("AnotherFile.cs", "This is a test", developerB);
 
                 IList<Graph> series = await ProvidingGraphSeriesAsync();
-                Assert.AreEqual(3, series.Count);
+                Assert.That(series.Count, Is.EqualTo(3));
 
-                Assert.AreEqual(
-                    1,
-                    series[0].GetNode("firstFile.cs").IntAttributes[NumberOfCommits]
-                );
+                Assert.That(series[0].GetNode("firstFile.cs").IntAttributes[NumberOfCommits],
+                            Is.EqualTo(1));
 
-                Assert.AreEqual(
-                    1,
-                    series[1].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits]
-                );
-                Assert.AreEqual(
-                    1,
-                    series[1].GetNode("firstFile.cs").IntAttributes[NumberOfCommits]
-                );
+                Assert.That(series[1].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits],
+                            Is.EqualTo(1));
+                Assert.That(series[1].GetNode("firstFile.cs").IntAttributes[NumberOfCommits],
+                            Is.EqualTo(1));
 
-                Assert.AreEqual(
-                    2,
-                    series[2].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits]
-                );
-                Assert.AreEqual(
-                    1,
-                    series[2].GetNode("firstFile.cs").IntAttributes[NumberOfCommits]
-                );
+                Assert.That(series[2].GetNode("AnotherFile.cs").IntAttributes[NumberOfCommits],
+                            Is.EqualTo(2));
+                Assert.That(series[2].GetNode("firstFile.cs").IntAttributes[NumberOfCommits],
+                            Is.EqualTo(1));
             });
         }
 
@@ -198,17 +188,18 @@ namespace SEE.GraphProviders
                 );
 
                 Graph g = await ProvidingGraphAsync();
-                Assert.NotNull(g.GetNode("firstFile.cs"));
+                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
                 Node n1 = g.GetNode("firstFile.cs");
-                Assert.AreEqual(1, n1.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(1, n1.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n1.IntAttributes[NumberOfCommits], Is.EqualTo(1));
+                Assert.That(n1.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
 
-                Assert.NotNull(g.GetNode("AnotherFile.cs"));
+                Assert.That(g.GetNode("AnotherFile.cs"), Is.Not.Null, "There is no node AnotherFile.cs.");
                 Node n2 = g.GetNode("AnotherFile.cs");
-                Assert.AreEqual(2, n2.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(2, n2.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n2.IntAttributes[NumberOfCommits], Is.EqualTo(2));
+                Assert.That(n2.IntAttributes[NumberOfDevelopers], Is.EqualTo(2));
 
-                Assert.NotNull(g.GetNode("dir1/dir2/actualFile.cs"));
+                Assert.That(g.GetNode("dir1/dir2/actualFile.cs"), Is.Not.Null,
+                            "There is no node dir1/dir2/actualFile.cs.");
             });
         }
 
@@ -221,13 +212,13 @@ namespace SEE.GraphProviders
 
                 Graph g = await ProvidingGraphAsync(date: "2024/12/01");
                 // This file should be too old by now
-                Assert.AreEqual(0, g.GetNode("firstFile.cs").IntAttributes[NumberOfDevelopers]);
-                Assert.AreEqual(0, g.GetNode("firstFile.cs").IntAttributes[NumberOfCommits]);
+                Assert.That(g.GetNode("firstFile.cs").IntAttributes[NumberOfDevelopers], Is.EqualTo(0));
+                Assert.That(g.GetNode("firstFile.cs").IntAttributes[NumberOfCommits], Is.EqualTo(0));
                 Graph g2 = await ProvidingGraphAsync();
-                Assert.NotNull(g2.GetNode("firstFile.cs"));
+                Assert.That(g2.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
                 Node n = g2.GetNode("firstFile.cs");
-                Assert.AreEqual(1, n.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(1, n.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(1));
+                Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });
         }
 
@@ -241,11 +232,11 @@ namespace SEE.GraphProviders
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.DoesNotThrow(() => g.GetNode("firstFile.cs"));
-                Assert.NotNull(g.GetNode("firstFile.cs"));
+                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
+                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
                 Node n = g.GetNode("firstFile.cs");
-                Assert.AreEqual(2, n.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(2, n.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
+                Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(2));
             });
         }
 
@@ -268,11 +259,11 @@ namespace SEE.GraphProviders
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.DoesNotThrow(() => g.GetNode("firstFile.cs"));
-                Assert.NotNull(g.GetNode("firstFile.cs"));
+                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
+                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
                 Node n = g.GetNode("firstFile.cs");
-                Assert.AreEqual(2, n.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(1, n.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
+                Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });
         }
 
@@ -287,13 +278,13 @@ namespace SEE.GraphProviders
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.DoesNotThrow(() => g.GetNode("firstFile.cs"));
-                Assert.NotNull(g.GetNode("firstFile.cs"));
+                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
+                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
                 Node n = g.GetNode("firstFile.cs");
-                Assert.AreEqual(2, n.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(1, n.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
+                Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
 
-                Assert.IsNull(g.GetNode("otherfile.notcs"));
+                Assert.That(g.GetNode("otherfile.notcs"), Is.Null, "There must be no node otherfile.notcs.");
             });
         }
 
@@ -307,11 +298,11 @@ namespace SEE.GraphProviders
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.DoesNotThrow(() => g.GetNode("firstFile.cs"));
-                Assert.NotNull(g.GetNode("firstFile.cs"));
+                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
+                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
                 Node n = g.GetNode("firstFile.cs");
-                Assert.AreEqual(2, n.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(1, n.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(2));
+                Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });
         }
 
@@ -323,7 +314,7 @@ namespace SEE.GraphProviders
                 WriteFile("firstFile.cs", "This is a test", developerA);
 
                 Graph g = await ProvidingGraphAsync();
-                Assert.IsNull(g.GetNode("file/does/not/exists"));
+                Assert.That(g.GetNode("file/does/not/exists"), Is.Null, "There must be no node file/does/not/exists.");
             });
         }
 
@@ -336,11 +327,11 @@ namespace SEE.GraphProviders
 
                 Graph g = await ProvidingGraphAsync();
                 // Check data of firstFile.cs
-                Assert.DoesNotThrow(() => g.GetNode("firstFile.cs"));
-                Assert.NotNull(g.GetNode("firstFile.cs"));
+                Assert.That(() => g.GetNode("firstFile.cs"), Throws.Nothing);
+                Assert.That(g.GetNode("firstFile.cs"), Is.Not.Null, "There is no node firstFile.cs.");
                 Node n = g.GetNode("firstFile.cs");
-                Assert.AreEqual(1, n.IntAttributes[NumberOfCommits]);
-                Assert.AreEqual(1, n.IntAttributes[NumberOfDevelopers]);
+                Assert.That(n.IntAttributes[NumberOfCommits], Is.EqualTo(1));
+                Assert.That(n.IntAttributes[NumberOfDevelopers], Is.EqualTo(1));
             });
         }
 

--- a/Assets/SEETests/TestGitSEE.cs
+++ b/Assets/SEETests/TestGitSEE.cs
@@ -76,7 +76,8 @@ namespace SEE.VCS
             p.End(true);
             //Debug.Log($"Number of commits between {oldCommit} and {newCommit}: {commits.Count()}\n");
             //Print(commits);
-            Assert.AreEqual(expectedCount, commits.Count(), $"Expected {expectedCount} commits between {oldCommit} and {newCommit}, but found {commits.Count()}.");
+            Assert.That(commits.Count(), Is.EqualTo(expectedCount),
+                        $"Number of commits between {oldCommit} and {newCommit}.");
         }
 
         /// <summary>
@@ -181,7 +182,8 @@ namespace SEE.VCS
             GitRepository repo = new(new DataPath(Path.GetDirectoryName(Application.dataPath)),
                                      new Filter(globbing: pathGlobbing, repositoryPaths: null, branches: null));
             IList<string> commits = repo.CommitsBetween(oldCommit, newCommit);
-            Assert.AreEqual(expected, commits);
+            Assert.That(commits, Is.EqualTo(expected),
+                        $"Commits between {oldCommit} and {newCommit} in topological order.");
         }
 
         /// <summary>

--- a/Assets/SEETests/TestGraph.cs
+++ b/Assets/SEETests/TestGraph.cs
@@ -29,27 +29,27 @@ namespace SEE.DataModel.DG
             Node n2 = NewNode(g, "n2");
             Node n3 = NewNode(g, "n3");
 
-            Assert.AreEqual(new HashSet<Edge>(), AsSet(n1.Outgoings));
+            Assert.That(AsSet(n1.Outgoings), Is.EqualTo(new HashSet<Edge>()));
             Edge call_n1_n1 = NewEdge(g, n1, n1);
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n1 }, AsSet(n1.Outgoings));
+            Assert.That(AsSet(n1.Outgoings), Is.EqualTo(new HashSet<Edge> { call_n1_n1 }));
             Edge call_n1_n2 = NewEdge(g, n1, n2);
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n1, call_n1_n2 }, AsSet(n1.Outgoings));
+            Assert.That(AsSet(n1.Outgoings), Is.EqualTo(new HashSet<Edge> { call_n1_n1, call_n1_n2 }));
             Edge call_n1_n3 = NewEdge(g, n1, n3);
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3 }, AsSet(n1.Outgoings));
+            Assert.That(AsSet(n1.Outgoings), Is.EqualTo(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3 }));
             Edge use_n1_n3_a = NewEdge(g, n1, n3, "use");
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a }, AsSet(n1.Outgoings));
+            Assert.That(AsSet(n1.Outgoings), Is.EqualTo(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a }));
             Edge use_n1_n3_b = NewEdge(g, n1, n3, "abuse");
             // We have overridden Equals() for edges so that they are considered the same if
             // they have the same type, same source and target linknames, and same attributes.
             // Based on this comparison, use_n1_n3_a and use_n1_n3_b are equal. To make them different,
             // we set an attribute for the latter.
             use_n1_n3_b.SetToggle("Duplicated");
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a, use_n1_n3_b }, AsSet(n1.Outgoings));
+            Assert.That(AsSet(n1.Outgoings), Is.EqualTo(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a, use_n1_n3_b }));
 
-            Assert.AreEqual(new HashSet<Edge>(), AsSet(n1.FromTo(n3, "none")));
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n3 }, AsSet(n1.FromTo(n3, "call")));
-            Assert.AreEqual(new HashSet<Edge> { use_n1_n3_a }, AsSet(n1.FromTo(n3, "use")));
-            Assert.AreEqual(new HashSet<Edge> { use_n1_n3_b }, AsSet(n1.FromTo(n3, "abuse")));
+            Assert.That(AsSet(n1.FromTo(n3, "none")), Is.EqualTo(new HashSet<Edge>()));
+            Assert.That(AsSet(n1.FromTo(n3, "call")), Is.EqualTo(new HashSet<Edge> { call_n1_n3 }));
+            Assert.That(AsSet(n1.FromTo(n3, "use")), Is.EqualTo(new HashSet<Edge> { use_n1_n3_a }));
+            Assert.That(AsSet(n1.FromTo(n3, "abuse")), Is.EqualTo(new HashSet<Edge> { use_n1_n3_b }));
 
             Edge call_n2_n3 = NewEdge(g, n2, n3);
 
@@ -58,25 +58,25 @@ namespace SEE.DataModel.DG
             HashSet<Node> nodes = new HashSet<Node> { n1, n2, n3 };
             HashSet<Edge> edges = new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a, use_n1_n3_b, call_n2_n3, call_n2_n2 };
 
-            Assert.AreEqual(nodes.Count, g.NodeCount);
-            Assert.AreEqual(edges.Count, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(nodes.Count));
+            Assert.That(g.EdgeCount, Is.EqualTo(edges.Count));
 
-            Assert.AreEqual(nodes, g.Nodes());
-            Assert.AreEqual(edges, g.Edges());
+            Assert.That(g.Nodes(), Is.EqualTo(nodes));
+            Assert.That(g.Edges(), Is.EqualTo(edges));
 
             g.RemoveEdge(use_n1_n3_b);
             edges = new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a, call_n2_n3, call_n2_n2 };
-            Assert.AreEqual(nodes.Count, g.NodeCount);
-            Assert.AreEqual(edges.Count, g.EdgeCount);
-            Assert.AreEqual(nodes, g.Nodes());
-            Assert.AreEqual(edges, g.Edges());
+            Assert.That(g.NodeCount, Is.EqualTo(nodes.Count));
+            Assert.That(g.EdgeCount, Is.EqualTo(edges.Count));
+            Assert.That(g.Nodes(), Is.EqualTo(nodes));
+            Assert.That(g.Edges(), Is.EqualTo(edges));
 
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n3 }, AsSet(n1.FromTo(n3, "call")));
-            Assert.AreEqual(new HashSet<Edge> { use_n1_n3_a }, AsSet(n1.FromTo(n3, "use")));
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n2 }, AsSet(n1.FromTo(n2, "call")));
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n1 }, AsSet(n1.FromTo(n1, "call")));
-            Assert.AreEqual(new HashSet<Edge>(), AsSet(n1.FromTo(n2, "use")));
-            Assert.AreEqual(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a }, AsSet(n1.Outgoings));
+            Assert.That(AsSet(n1.FromTo(n3, "call")), Is.EqualTo(new HashSet<Edge> { call_n1_n3 }));
+            Assert.That(AsSet(n1.FromTo(n3, "use")), Is.EqualTo(new HashSet<Edge> { use_n1_n3_a }));
+            Assert.That(AsSet(n1.FromTo(n2, "call")), Is.EqualTo(new HashSet<Edge> { call_n1_n2 }));
+            Assert.That(AsSet(n1.FromTo(n1, "call")), Is.EqualTo(new HashSet<Edge> { call_n1_n1 }));
+            Assert.That(AsSet(n1.FromTo(n2, "use")), Is.EqualTo(new HashSet<Edge>()));
+            Assert.That(AsSet(n1.Outgoings), Is.EqualTo(new HashSet<Edge> { call_n1_n1, call_n1_n2, call_n1_n3, use_n1_n3_a }));
         }
 
         /// <summary>
@@ -112,26 +112,26 @@ namespace SEE.DataModel.DG
                 call_n1_n3, call_n3_n1
             };
 
-            Assert.AreEqual(nodes.Count, g.NodeCount);
-            Assert.AreEqual(edges.Count, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(nodes.Count));
+            Assert.That(g.EdgeCount, Is.EqualTo(edges.Count));
 
-            Assert.AreEqual(nodes, g.Nodes());
-            Assert.AreEqual(edges, g.Edges());
+            Assert.That(g.Nodes(), Is.EqualTo(nodes));
+            Assert.That(g.Edges(), Is.EqualTo(edges));
 
-            Assert.AreEqual(n1.Outgoings,
-                            new HashSet<Edge> { call_n1_n2, use_n1_n2, call_n1_n3 });
-            Assert.AreEqual(n1.Incomings,
-                            new HashSet<Edge> { call_n3_n1 });
+            Assert.That(n1.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n1_n2, use_n1_n2, call_n1_n3 }));
+            Assert.That(n1.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n3_n1 }));
 
-            Assert.AreEqual(n2.Outgoings,
-                            new HashSet<Edge> { call_n2_n3, use_n2_n3, call_n2_n2, use_n2_n2 });
-            Assert.AreEqual(n2.Incomings,
-                            new HashSet<Edge> { call_n1_n2, use_n1_n2, call_n2_n2, use_n2_n2 });
+            Assert.That(n2.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n2_n3, use_n2_n3, call_n2_n2, use_n2_n2 }));
+            Assert.That(n2.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n1_n2, use_n1_n2, call_n2_n2, use_n2_n2 }));
 
-            Assert.AreEqual(n3.Outgoings,
-                            new HashSet<Edge> { call_n3_n1 });
-            Assert.AreEqual(n3.Incomings,
-                            new HashSet<Edge> { call_n2_n3, use_n2_n3, call_n1_n3 });
+            Assert.That(n3.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n3_n1 }));
+            Assert.That(n3.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n2_n3, use_n2_n3, call_n1_n3 }));
 
             // If a node is removed, all its incoming and outgoing edges must
             // be removed, too, and its successors and predecessors must be adjusted, too.
@@ -140,26 +140,26 @@ namespace SEE.DataModel.DG
             nodes = new HashSet<Node> { n1, n3 };
             edges = new HashSet<Edge> { call_n1_n3, call_n3_n1 };
 
-            Assert.AreEqual(nodes.Count, g.NodeCount);
-            Assert.AreEqual(edges.Count, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(nodes.Count));
+            Assert.That(g.EdgeCount, Is.EqualTo(edges.Count));
 
-            Assert.AreEqual(nodes, g.Nodes());
-            Assert.AreEqual(edges, g.Edges());
+            Assert.That(g.Nodes(), Is.EqualTo(nodes));
+            Assert.That(g.Edges(), Is.EqualTo(edges));
 
-            Assert.AreEqual(n1.Outgoings,
-                            new HashSet<Edge> { call_n1_n3 });
-            Assert.AreEqual(n1.Incomings,
-                            new HashSet<Edge> { call_n3_n1 });
+            Assert.That(n1.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n1_n3 }));
+            Assert.That(n1.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n3_n1 }));
 
-            Assert.AreEqual(n2.Outgoings,
-                            new HashSet<Edge>());
-            Assert.AreEqual(n2.Incomings,
-                            new HashSet<Edge>());
+            Assert.That(n2.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
+            Assert.That(n2.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
 
-            Assert.AreEqual(n3.Outgoings,
-                            new HashSet<Edge> { call_n3_n1 });
-            Assert.AreEqual(n3.Incomings,
-                            new HashSet<Edge> { call_n1_n3 });
+            Assert.That(n3.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n3_n1 }));
+            Assert.That(n3.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n1_n3 }));
 
             // If an edge is removed, it must be removed from the incoming and outgoing
             // edges of its source and target, respectively.
@@ -167,42 +167,42 @@ namespace SEE.DataModel.DG
             nodes = new HashSet<Node> { n1, n3 };
             edges = new HashSet<Edge> { call_n1_n3 };
 
-            Assert.AreEqual(nodes.Count, g.NodeCount);
-            Assert.AreEqual(edges.Count, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(nodes.Count));
+            Assert.That(g.EdgeCount, Is.EqualTo(edges.Count));
 
-            Assert.AreEqual(nodes, g.Nodes());
-            Assert.AreEqual(edges, g.Edges());
+            Assert.That(g.Nodes(), Is.EqualTo(nodes));
+            Assert.That(g.Edges(), Is.EqualTo(edges));
 
-            Assert.AreEqual(n1.Outgoings,
-                            new HashSet<Edge> { call_n1_n3 });
-            Assert.AreEqual(n1.Incomings,
-                            new HashSet<Edge>());
+            Assert.That(n1.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n1_n3 }));
+            Assert.That(n1.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
 
-            Assert.AreEqual(n3.Outgoings,
-                            new HashSet<Edge>());
-            Assert.AreEqual(n3.Incomings,
-                            new HashSet<Edge> { call_n1_n3 });
+            Assert.That(n3.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
+            Assert.That(n3.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge> { call_n1_n3 }));
 
             // After removing n3, the graph should have only a single node left.
             g.RemoveNode(n3);
             nodes = new HashSet<Node> { n1 };
             edges = new HashSet<Edge>();
 
-            Assert.AreEqual(nodes.Count, g.NodeCount);
-            Assert.AreEqual(edges.Count, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(nodes.Count));
+            Assert.That(g.EdgeCount, Is.EqualTo(edges.Count));
 
-            Assert.AreEqual(nodes, g.Nodes());
-            Assert.AreEqual(edges, g.Edges());
+            Assert.That(g.Nodes(), Is.EqualTo(nodes));
+            Assert.That(g.Edges(), Is.EqualTo(edges));
 
-            Assert.AreEqual(n1.Outgoings,
-                            new HashSet<Edge>());
-            Assert.AreEqual(n1.Incomings,
-                            new HashSet<Edge>());
+            Assert.That(n1.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
+            Assert.That(n1.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
 
-            Assert.AreEqual(n3.Outgoings,
-                            new HashSet<Edge>());
-            Assert.AreEqual(n3.Incomings,
-                            new HashSet<Edge>());
+            Assert.That(n3.Outgoings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
+            Assert.That(n3.Incomings,
+                        Is.EquivalentTo(new HashSet<Edge>()));
         }
 
         [Test]
@@ -219,9 +219,9 @@ namespace SEE.DataModel.DG
 
             AssertHasChild(g, parent: r, child: o1);
             AssertHasChild(g, parent: r, child: o2);
-            Assert.IsNull(d.ItsGraph);
-            Assert.IsNull(d.Parent);
-            Assert.AreEqual(0, d.NumberOfChildren());
+            Assert.That(d.ItsGraph, Is.Null);
+            Assert.That(d.Parent, Is.Null);
+            Assert.That(d.NumberOfChildren(), Is.EqualTo(0));
         }
 
         [Test]
@@ -236,12 +236,12 @@ namespace SEE.DataModel.DG
 
             g.RemoveNode(d, orphansBecomeRoots: true);
 
-            Assert.AreEqual(0, r.NumberOfChildren());
-            Assert.IsNull(o1.Parent);
-            Assert.IsNull(o2.Parent);
-            Assert.IsNull(d.ItsGraph);
-            Assert.IsNull(d.Parent);
-            Assert.AreEqual(0, d.NumberOfChildren());
+            Assert.That(r.NumberOfChildren(), Is.EqualTo(0));
+            Assert.That(o1.Parent, Is.Null);
+            Assert.That(o2.Parent, Is.Null);
+            Assert.That(d.ItsGraph, Is.Null);
+            Assert.That(d.Parent, Is.Null);
+            Assert.That(d.NumberOfChildren(), Is.EqualTo(0));
         }
 
         [Test]
@@ -250,52 +250,52 @@ namespace SEE.DataModel.DG
             string t = "Routine";
 
             Graph g = NewEmptyGraph();
-            Assert.AreEqual(0, g.MaxDepth);
+            Assert.That(g.MaxDepth, Is.EqualTo(0));
 
             Node a = NewNode(g, "a", t);
             Node b = NewNode(g, "b", t);
 
             // hierarchy:
             //  a   b
-            Assert.AreEqual(0, a.Level);
-            Assert.AreEqual(0, b.Level);
-            Assert.AreEqual(1, a.Depth());
-            Assert.AreEqual(1, b.Depth());
-            Assert.AreEqual(1, g.MaxDepth);
+            Assert.That(a.Level, Is.EqualTo(0));
+            Assert.That(b.Level, Is.EqualTo(0));
+            Assert.That(a.Depth(), Is.EqualTo(1));
+            Assert.That(b.Depth(), Is.EqualTo(1));
+            Assert.That(g.MaxDepth, Is.EqualTo(1));
 
             a.Reparent(null);
             // hierarchy:
             //  a   b
             // no change expected
-            Assert.AreEqual(0, a.Level);
-            Assert.AreEqual(0, b.Level);
-            Assert.AreEqual(1, a.Depth());
-            Assert.AreEqual(1, b.Depth());
-            Assert.AreEqual(1, g.MaxDepth);
+            Assert.That(a.Level, Is.EqualTo(0));
+            Assert.That(b.Level, Is.EqualTo(0));
+            Assert.That(a.Depth(), Is.EqualTo(1));
+            Assert.That(b.Depth(), Is.EqualTo(1));
+            Assert.That(g.MaxDepth, Is.EqualTo(1));
 
             Node bc = Child(g, b, "bc", t);
             // hierarchy:
             //  a   b
             //      |
             //      bc
-            Assert.AreEqual(0, a.Level);
-            Assert.AreEqual(0, b.Level);
-            Assert.AreEqual(1, bc.Level);
-            Assert.AreEqual(1, a.Depth());
-            Assert.AreEqual(2, b.Depth());
-            Assert.AreEqual(1, bc.Depth());
-            Assert.AreEqual(2, g.MaxDepth);
+            Assert.That(a.Level, Is.EqualTo(0));
+            Assert.That(b.Level, Is.EqualTo(0));
+            Assert.That(bc.Level, Is.EqualTo(1));
+            Assert.That(a.Depth(), Is.EqualTo(1));
+            Assert.That(b.Depth(), Is.EqualTo(2));
+            Assert.That(bc.Depth(), Is.EqualTo(1));
+            Assert.That(g.MaxDepth, Is.EqualTo(2));
 
             bc.Reparent(null);
             // hierarchy:
             //  a   b  bc
-            Assert.AreEqual(0, a.Level);
-            Assert.AreEqual(1, a.Depth());
-            Assert.AreEqual(0, b.Level);
-            Assert.AreEqual(1, b.Depth());
-            Assert.AreEqual(0, bc.Level);
-            Assert.AreEqual(1, bc.Depth());
-            Assert.AreEqual(1, g.MaxDepth);
+            Assert.That(a.Level, Is.EqualTo(0));
+            Assert.That(a.Depth(), Is.EqualTo(1));
+            Assert.That(b.Level, Is.EqualTo(0));
+            Assert.That(b.Depth(), Is.EqualTo(1));
+            Assert.That(bc.Level, Is.EqualTo(0));
+            Assert.That(bc.Depth(), Is.EqualTo(1));
+            Assert.That(g.MaxDepth, Is.EqualTo(1));
 
             Node ac = Child(g, a, "ac", t);
             Node acc = Child(g, ac, "acc", t);
@@ -307,21 +307,21 @@ namespace SEE.DataModel.DG
             // ac   bc
             //  |   |
             // acc bcc
-            Assert.AreEqual(0, a.Level);
-            Assert.AreEqual(3, a.Depth());
-            Assert.AreEqual(1, ac.Level);
-            Assert.AreEqual(2, ac.Depth());
-            Assert.AreEqual(2, acc.Level);
-            Assert.AreEqual(1, acc.Depth());
+            Assert.That(a.Level, Is.EqualTo(0));
+            Assert.That(a.Depth(), Is.EqualTo(3));
+            Assert.That(ac.Level, Is.EqualTo(1));
+            Assert.That(ac.Depth(), Is.EqualTo(2));
+            Assert.That(acc.Level, Is.EqualTo(2));
+            Assert.That(acc.Depth(), Is.EqualTo(1));
 
-            Assert.AreEqual(0, b.Level);
-            Assert.AreEqual(3, b.Depth());
-            Assert.AreEqual(1, bc.Level);
-            Assert.AreEqual(2, bc.Depth());
-            Assert.AreEqual(2, bcc.Level);
-            Assert.AreEqual(1, bcc.Depth());
+            Assert.That(b.Level, Is.EqualTo(0));
+            Assert.That(b.Depth(), Is.EqualTo(3));
+            Assert.That(bc.Level, Is.EqualTo(1));
+            Assert.That(bc.Depth(), Is.EqualTo(2));
+            Assert.That(bcc.Level, Is.EqualTo(2));
+            Assert.That(bcc.Depth(), Is.EqualTo(1));
 
-            Assert.AreEqual(3, g.MaxDepth);
+            Assert.That(g.MaxDepth, Is.EqualTo(3));
             bc.Reparent(ac);
             // hierarchy:
             //    a     b
@@ -332,19 +332,19 @@ namespace SEE.DataModel.DG
             // acc bc
             //      |
             //     bcc
-            Assert.AreEqual(0, a.Level);
-            Assert.AreEqual(4, a.Depth());
-            Assert.AreEqual(1, ac.Level);
-            Assert.AreEqual(3, ac.Depth());
-            Assert.AreEqual(2, acc.Level);
-            Assert.AreEqual(1, acc.Depth());
-            Assert.AreEqual(2, bc.Level);
-            Assert.AreEqual(2, bc.Depth());
-            Assert.AreEqual(3, bcc.Level);
-            Assert.AreEqual(1, bcc.Depth());
-            Assert.AreEqual(0, b.Level);
-            Assert.AreEqual(1, b.Depth());
-            Assert.AreEqual(4, g.MaxDepth);
+            Assert.That(a.Level, Is.EqualTo(0));
+            Assert.That(a.Depth(), Is.EqualTo(4));
+            Assert.That(ac.Level, Is.EqualTo(1));
+            Assert.That(ac.Depth(), Is.EqualTo(3));
+            Assert.That(acc.Level, Is.EqualTo(2));
+            Assert.That(acc.Depth(), Is.EqualTo(1));
+            Assert.That(bc.Level, Is.EqualTo(2));
+            Assert.That(bc.Depth(), Is.EqualTo(2));
+            Assert.That(bcc.Level, Is.EqualTo(3));
+            Assert.That(bcc.Depth(), Is.EqualTo(1));
+            Assert.That(b.Level, Is.EqualTo(0));
+            Assert.That(b.Depth(), Is.EqualTo(1));
+            Assert.That(g.MaxDepth, Is.EqualTo(4));
         }
 
         /// <summary>
@@ -373,55 +373,68 @@ namespace SEE.DataModel.DG
             makeIrrelevant(ba);
             Node baa = Child(g, ba, "baa");
             makeRelevant(baa);
-            Assert.IsTrue(isRelevant(baa));
+            Assert.That(isRelevant(baa), Is.True,
+                        $"{baa.ID} should be relevant.");
             Node baaa = Child(g, baa, "baaa");
             makeIrrelevant(baaa);
             Node baaaa = Child(g, baaa, "baaaa");
             makeRelevant(baaaa);
-            Assert.IsTrue(isRelevant(baaaa));
+            Assert.That(isRelevant(baaaa), Is.True,
+                        $"{baaaa.ID} should be relevant.");
             Node bb = Child(g, b, "bb");
             makeRelevant(bb);
-            Assert.IsTrue(isRelevant(bb));
+            Assert.That(isRelevant(bb), Is.True,
+                        $"{bb.ID} should be relevant.");
             Node bba = Child(g, bb, "bba");
             makeRelevant(bba);
-            Assert.IsTrue(isRelevant(bba));
+            Assert.That(isRelevant(bba), Is.True,
+                        $"{bba.ID} should be relevant.");
             Node bbaa = Child(g, bba, "bbaa");
             makeIrrelevant(bbaa);
             Node bc = Child(g, b, "bc");
             makeIrrelevant(bc);
             Node bca = Child(g, bc, "bca");
             makeRelevant(bca);
-            Assert.IsTrue(isRelevant(bca));
+            Assert.That(isRelevant(bca), Is.True,
+                        $"{bca.ID} should be relevant.");
             Node bcaa = Child(g, bca, "bcaa");
             makeRelevant(bcaa);
-            Assert.IsTrue(isRelevant(bcaa));
+            Assert.That(isRelevant(bcaa), Is.True,
+                        $"{bcaa.ID} should be relevant.");
             Node bcab = Child(g, bca, "bcab");
             makeRelevant(bcab);
-            Assert.IsTrue(isRelevant(bcab));
+            Assert.That(isRelevant(bcab), Is.True,
+                        $"{bcab.ID} should be relevant.");
             Node bcb = Child(g, bc, "bcb");
             makeIrrelevant(bcb);
             Node bcba = Child(g, bcb, "bcba");
             makeRelevant(bcba);
-            Assert.IsTrue(isRelevant(bcba));
+            Assert.That(isRelevant(bcba), Is.True,
+                        $"{bcba.ID} should be relevant.");
             Node bd = Child(g, b, "bd");
             makeRelevant(bd);
-            Assert.IsTrue(isRelevant(bd));
+            Assert.That(isRelevant(bd), Is.True,
+                        $"{bd.ID} should be relevant.");
             Node bda = Child(g, bd, "bda");
             makeIrrelevant(bda);
             Node bdaa = Child(g, bda, "bdaa");
             makeRelevant(bdaa);
-            Assert.IsTrue(isRelevant(bdaa));
+            Assert.That(isRelevant(bdaa), Is.True,
+                        $"{bdaa.ID} should be relevant.");
             Node c = NewNode(g, "c");
             makeRelevant(c);
-            Assert.IsTrue(isRelevant(c));
+            Assert.That(isRelevant(c), Is.True,
+                        $"{c.ID} should be relevant.");
             Node d = NewNode(g, "d");
             makeIrrelevant(d);
             Node da = Child(g, d, "da");
             makeRelevant(da);
-            Assert.IsTrue(isRelevant(da));
+            Assert.That(isRelevant(da), Is.True,
+                        $"{da.ID} should be relevant.");
             Node e = NewNode(g, "e");
             makeRelevant(e);
-            Assert.IsTrue(isRelevant(e));
+            Assert.That(isRelevant(e), Is.True,
+                        $"{e.ID} should be relevant.");
             Node ea = Child(g, e, "ea");
             makeIrrelevant(ea);
             // makeIrrelevant may have no effect, which is why we have to count this way.
@@ -436,43 +449,56 @@ namespace SEE.DataModel.DG
             makeIrrelevant(e0);
             Edge e1 = NewEdge(g, a, ba);
             makeRelevant(e1);
-            Assert.IsTrue(isRelevant(e1));
+            Assert.That(isRelevant(e1), Is.True,
+                        $"{e1.ID} should be relevant.");
             Edge e2 = NewEdge(g, a, b);
             makeRelevant(e2);
-            Assert.IsTrue(isRelevant(e2));
+            Assert.That(isRelevant(e2), Is.True,
+                        $"{e2.ID} should be relevant.");
             Edge e3 = NewEdge(g, baa, baaa);
             makeRelevant(e3);
-            Assert.IsTrue(isRelevant(e3));
+            Assert.That(isRelevant(e3), Is.True,
+                        $"{e3.ID} should be relevant.");
             Edge e4 = NewEdge(g, baa, bba);
             makeRelevant(e4);
-            Assert.IsTrue(isRelevant(e4));
+            Assert.That(isRelevant(e4), Is.True,
+                        $"{e4.ID} should be relevant.");
             Edge e5 = NewEdge(g, bb, bba);
             makeRelevant(e5);
-            Assert.IsTrue(isRelevant(e5));
+            Assert.That(isRelevant(e5), Is.True,
+                        $"{e5.ID} should be relevant.");
             Edge e6 = NewEdge(g, bbaa, bba);
             makeRelevant(e6);
-            Assert.IsTrue(isRelevant(e6));
+            Assert.That(isRelevant(e6), Is.True,
+                        $"{e6.ID} should be relevant.");
             Edge e7 = NewEdge(g, bcab, bcba);
             makeRelevant(e7);
-            Assert.IsTrue(isRelevant(e7));
+            Assert.That(isRelevant(e7), Is.True,
+                        $"{e7.ID} should be relevant.");
             Edge e8 = NewEdge(g, bdaa, baaa);
             makeRelevant(e8);
-            Assert.IsTrue(isRelevant(e8));
+            Assert.That(isRelevant(e8), Is.True,
+                        $"{e8.ID} should be relevant.");
             Edge e9 = NewEdge(g, bdaa, bd);
             makeRelevant(e9);
-            Assert.IsTrue(isRelevant(e9));
+            Assert.That(isRelevant(e9), Is.True,
+                        $"{e9.ID} should be relevant.");
             Edge e10 = NewEdge(g, bdaa, bdaa);
             makeRelevant(e10);
-            Assert.IsTrue(isRelevant(e10));
+            Assert.That(isRelevant(e10), Is.True,
+                        $"{e10.ID} should be relevant.");
             Edge e11 = NewEdge(g, c, e);
             makeRelevant(e11);
-            Assert.IsTrue(isRelevant(e11));
+            Assert.That(isRelevant(e11), Is.True,
+                        $"{e11.ID} should be relevant.");
             Edge e12 = NewEdge(g, d, d);
             makeRelevant(e12);
-            Assert.IsTrue(isRelevant(e12));
+            Assert.That(isRelevant(e12), Is.True,
+                        $"{e12.ID} should be relevant.");
             Edge e13 = NewEdge(g, ea, d);
             makeRelevant(e13);
-            Assert.IsTrue(isRelevant(e13));
+            Assert.That(isRelevant(e13), Is.True,
+                        $"{e13.ID} should be relevant.");
             Edge e14 = NewEdge(g, bcba, bd);
             makeIrrelevant(e14);
 
@@ -481,27 +507,29 @@ namespace SEE.DataModel.DG
             // Nodes in subgraph must be relevant.
             foreach (Node node in subgraph.Nodes())
             {
-                Assert.That(isRelevant(node));
+                Assert.That(isRelevant(node), Is.True,
+                            $"{node.ID} should be relevant.");
             }
 
             foreach (Edge edge in subgraph.Edges())
             {
-                Assert.That(isRelevant(edge));
+                Assert.That(isRelevant(edge), Is.True,
+                            $"{edge.ID} should be relevant.");
             }
 
-            Assert.AreEqual(relevantNodes, subgraph.NodeCount);
-            Assert.IsNull(Pendant(subgraph, a));
-            Assert.IsNull(Pendant(subgraph, b));
-            Assert.IsNull(Pendant(subgraph, ba));
+            Assert.That(subgraph.NodeCount, Is.EqualTo(relevantNodes));
+            Assert.That(Pendant(subgraph, a), Is.Null);
+            Assert.That(Pendant(subgraph, b), Is.Null);
+            Assert.That(Pendant(subgraph, ba), Is.Null);
             Node BAA = Pendant(subgraph, baa) as Node;
             Node BB = Pendant(subgraph, bb) as Node;
-            Assert.IsNull(Pendant(subgraph, bc));
+            Assert.That(Pendant(subgraph, bc), Is.Null);
             Node BCA = Pendant(subgraph, bca) as Node;
-            Assert.IsNull(Pendant(subgraph, bcb));
+            Assert.That(Pendant(subgraph, bcb), Is.Null);
             Node BCBA = Pendant(subgraph, bcba) as Node;
             Node BD = Pendant(subgraph, bd) as Node;
             Node C = Pendant(subgraph, c) as Node;
-            Assert.IsNull(Pendant(subgraph, d));
+            Assert.That(Pendant(subgraph, d), Is.Null);
             Node DA = Pendant(subgraph, da) as Node;
             Node E = Pendant(subgraph, e) as Node;
             Node BAAAA = Pendant(subgraph, baaaa) as Node;
@@ -510,22 +538,38 @@ namespace SEE.DataModel.DG
             Node BCAB = Pendant(subgraph, bcab) as Node;
             Node BDAA = Pendant(subgraph, bdaa) as Node;
 
-            Assert.That(BAA.IsRoot);
-            Assert.That(BB.IsRoot);
-            Assert.That(BCA.IsRoot);
-            Assert.That(BCBA.IsRoot);
-            Assert.That(BD.IsRoot);
-            Assert.That(C.IsRoot);
-            Assert.That(DA.IsRoot);
-            Assert.That(E.IsRoot);
-            Assert.That(BAAAA.IsLeaf);
-            Assert.That(BBA.IsLeaf);
-            Assert.That(BCAA.IsLeaf);
-            Assert.That(BCAB.IsLeaf);
-            Assert.That(BCBA.IsLeaf);
-            Assert.That(BDAA.IsLeaf);
-            Assert.That(C.IsLeaf);
-            Assert.That(E.IsLeaf);
+            Assert.That(BAA.IsRoot, Is.True,
+                        $"{BAA.ID} should be a root.");
+            Assert.That(BB.IsRoot, Is.True,
+                        $"{BB.ID} should be a root.");
+            Assert.That(BCA.IsRoot, Is.True,
+                        $"{BCA.ID} should be a root.");
+            Assert.That(BCBA.IsRoot, Is.True,
+                        $"{BCBA.ID} should be a root.");
+            Assert.That(BD.IsRoot, Is.True,
+                        $"{BD.ID} should be a root.");
+            Assert.That(C.IsRoot, Is.True,
+                        $"{C.ID} should be a root.");
+            Assert.That(DA.IsRoot, Is.True,
+                        $"{DA.ID} should be a root.");
+            Assert.That(E.IsRoot, Is.True,
+                        $"{E.ID} should be a root.");
+            Assert.That(BAAAA.IsLeaf, Is.True,
+                        $"{BAAAA.ID} should be a leaf.");
+            Assert.That(BBA.IsLeaf, Is.True,
+                        $"{BBA.ID} should be a leaf.");
+            Assert.That(BCAA.IsLeaf, Is.True,
+                        $"{BCAA.ID} should be a leaf.");
+            Assert.That(BCAB.IsLeaf, Is.True,
+                        $"{BCAB.ID} should be a leaf.");
+            Assert.That(BCBA.IsLeaf, Is.True,
+                        $"{BCBA.ID} should be a leaf.");
+            Assert.That(BDAA.IsLeaf, Is.True,
+                        $"{BDAA.ID} should be a leaf.");
+            Assert.That(C.IsLeaf, Is.True,
+                        $"{C.ID} should be a leaf.");
+            Assert.That(E.IsLeaf, Is.True,
+                        $"{E.ID} should be a leaf.");
 
             AssertHasChild(subgraph, baa, baaaa);
             AssertHasChild(subgraph, bb, bba);
@@ -537,7 +581,7 @@ namespace SEE.DataModel.DG
             int relevantEdges = new List<Edge> { e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14 }.Count(isRelevant);
             // 9 edges are kept.
             // Kept edges: Those for which isRelevant returned true before subgraphing minus four "dangling" ones.
-            Assert.AreEqual(relevantEdges - 4, subgraph.EdgeCount);
+            Assert.That(subgraph.EdgeCount, Is.EqualTo(relevantEdges - 4));
             Assert.That(HasEdge(BAA, BAA));
             Assert.That(HasEdge(BAA, BBA));
             Assert.That(HasEdge(BB, BBA));
@@ -598,7 +642,7 @@ namespace SEE.DataModel.DG
             {
                 // Lifted self loops are not ignored.
                 Graph subgraph = g.SubgraphByNodeType(new List<string> { RootType }, false);
-                Assert.AreEqual(g.Nodes().Where(n => n.Type == RootType).Count(), subgraph.NodeCount);
+                Assert.That(subgraph.NodeCount, Is.EqualTo(g.Nodes().Where(n => n.Type == RootType).Count()));
 
                 Node A = Pendant(subgraph, a) as Node;
                 Node B = Pendant(subgraph, b) as Node;
@@ -613,12 +657,12 @@ namespace SEE.DataModel.DG
                 Assert.That(HasEdge(E, E));
                 Assert.That(HasEdge(A, C));
                 Assert.That(HasEdge(B, A));
-                Assert.AreEqual(7, subgraph.EdgeCount);
+                Assert.That(subgraph.EdgeCount, Is.EqualTo(7));
             }
             {
                 // Lifted self loops are ignored.
                 Graph subgraph = g.SubgraphByNodeType(new List<string> { RootType }, true);
-                Assert.AreEqual(g.Nodes().Where(n => n.Type == RootType).Count(), subgraph.NodeCount);
+                Assert.That(subgraph.NodeCount, Is.EqualTo(g.Nodes().Where(n => n.Type == RootType).Count()));
 
                 Node A = Pendant(subgraph, a) as Node;
                 Node B = Pendant(subgraph, b) as Node;
@@ -629,7 +673,7 @@ namespace SEE.DataModel.DG
                 Assert.That(HasEdge(A, A));
                 Assert.That(HasEdge(A, C));
                 Assert.That(HasEdge(B, A));
-                Assert.AreEqual(3, subgraph.EdgeCount);
+                Assert.That(subgraph.EdgeCount, Is.EqualTo(3));
             }
         }
 
@@ -671,14 +715,14 @@ namespace SEE.DataModel.DG
             Graph g = NewEmptyGraph();
             Node a = NewNode(g, "a");
             SubgraphMemento subgraph = a.DeleteTree();
-            Assert.IsNull(a.ItsGraph);
-            Assert.AreEqual(0, g.NodeCount);
-            Assert.AreEqual(0, g.EdgeCount);
+            Assert.That(a.ItsGraph, Is.Null);
+            Assert.That(g.NodeCount, Is.EqualTo(0));
+            Assert.That(g.EdgeCount, Is.EqualTo(0));
 
             subgraph.Restore();
             Assert.That(a.ItsGraph, Is.SameAs(g));
-            Assert.AreEqual(1, g.NodeCount);
-            Assert.AreEqual(0, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(1));
+            Assert.That(g.EdgeCount, Is.EqualTo(0));
         }
 
         /// <summary>
@@ -692,16 +736,16 @@ namespace SEE.DataModel.DG
             Node a = NewNode(g, "a");
             Edge e = NewEdge(g, a, a);
             SubgraphMemento subgraph = a.DeleteTree();
-            Assert.IsNull(a.ItsGraph);
-            Assert.IsNull(e.ItsGraph);
-            Assert.AreEqual(0, g.NodeCount);
-            Assert.AreEqual(0, g.EdgeCount);
+            Assert.That(a.ItsGraph, Is.Null);
+            Assert.That(e.ItsGraph, Is.Null);
+            Assert.That(g.NodeCount, Is.EqualTo(0));
+            Assert.That(g.EdgeCount, Is.EqualTo(0));
 
             subgraph.Restore();
             Assert.That(a.ItsGraph, Is.SameAs(g));
             Assert.That(e.ItsGraph, Is.SameAs(g));
-            Assert.AreEqual(1, g.NodeCount);
-            Assert.AreEqual(1, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(1));
+            Assert.That(g.EdgeCount, Is.EqualTo(1));
         }
 
         /// <summary>
@@ -740,7 +784,7 @@ namespace SEE.DataModel.DG
             Assert.That(b.ItsGraph, Is.SameAs(g));
             foreach (Node node in subgraphNodes)
             {
-                Assert.IsNull(node.ItsGraph);
+                Assert.That(node.ItsGraph, Is.Null);
             }
 
             // e1 and e2 are still in the graph, but all other edges are removed
@@ -748,11 +792,11 @@ namespace SEE.DataModel.DG
             Assert.That(e2.ItsGraph, Is.SameAs(g));
             foreach (Edge edge in subgraphEdges)
             {
-                Assert.IsNull(edge.ItsGraph);
+                Assert.That(edge.ItsGraph, Is.Null);
             }
 
-            Assert.AreEqual(2, g.NodeCount);
-            Assert.AreEqual(2, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(2));
+            Assert.That(g.EdgeCount, Is.EqualTo(2));
 
             subgraph.Restore();
             Assert.That(a.ItsGraph, Is.SameAs(g));
@@ -769,8 +813,8 @@ namespace SEE.DataModel.DG
                 Assert.That(edge.ItsGraph, Is.SameAs(g));
             }
 
-            Assert.AreEqual(subgraphNodes.Count + 2, g.NodeCount);
-            Assert.AreEqual(subgraphEdges.Count + 2, g.EdgeCount);
+            Assert.That(g.NodeCount, Is.EqualTo(subgraphNodes.Count + 2));
+            Assert.That(g.EdgeCount, Is.EqualTo(subgraphEdges.Count + 2));
         }
 
         /// <summary>
@@ -799,13 +843,14 @@ namespace SEE.DataModel.DG
             Edge e2 = NewEdge(g, a, b, "set");
 
             Graph sg = g.SubgraphBy(x => x is Node || (x is Edge e && e.Type == "set"));
-            Assert.AreEqual(floatAttributeValue, sg.GetFloat(floatAttribute));
-            Assert.AreEqual(intAttributeValue, sg.GetInt(intAttribute));
-            Assert.AreEqual(stringAttributeValue, sg.GetString(stringAttribute));
-            Assert.IsTrue(sg.HasToggle(toggleAttribute));
+            Assert.That(sg.GetFloat(floatAttribute), Is.EqualTo(floatAttributeValue));
+            Assert.That(sg.GetInt(intAttribute), Is.EqualTo(intAttributeValue));
+            Assert.That(sg.GetString(stringAttribute), Is.EqualTo(stringAttributeValue));
+            Assert.That(sg.HasToggle(toggleAttribute), Is.True,
+                        $"{sg.Name} has no toggle {toggleAttribute}.");
 
-            Assert.AreEqual(2, sg.NodeCount);
-            Assert.AreEqual(1, sg.EdgeCount);
+            Assert.That(sg.NodeCount, Is.EqualTo(2));
+            Assert.That(sg.EdgeCount, Is.EqualTo(1));
         }
 
         [Test]

--- a/Assets/SEETests/TestGraph.cs
+++ b/Assets/SEETests/TestGraph.cs
@@ -582,15 +582,15 @@ namespace SEE.DataModel.DG
             // 9 edges are kept.
             // Kept edges: Those for which isRelevant returned true before subgraphing minus four "dangling" ones.
             Assert.That(subgraph.EdgeCount, Is.EqualTo(relevantEdges - 4));
-            Assert.That(HasEdge(BAA, BAA));
-            Assert.That(HasEdge(BAA, BBA));
-            Assert.That(HasEdge(BB, BBA));
-            Assert.That(HasEdge(BBA, BBA));
-            Assert.That(HasEdge(BCAB, BCBA));
-            Assert.That(HasEdge(BDAA, BAA));
-            Assert.That(HasEdge(BDAA, BDAA));
-            Assert.That(HasEdge(BDAA, BD));
-            Assert.That(HasEdge(C, E));
+            Assert.That(HasEdge(BAA, BAA), Is.True, $"There must be an edge from {BAA.ID} to {BAA.ID}.");
+            Assert.That(HasEdge(BAA, BBA), Is.True, $"There must be an edge from {BAA.ID} to {BBA.ID}.");
+            Assert.That(HasEdge(BB, BBA), Is.True, $"There must be an edge from {BB.ID} to {BBA.ID}.");
+            Assert.That(HasEdge(BBA, BBA), Is.True, $"There must be an edge from {BBA.ID} to {BBA.ID}.");
+            Assert.That(HasEdge(BCAB, BCBA), Is.True, $"There must be an edge from {BCAB.ID} to {BCBA.ID}.");
+            Assert.That(HasEdge(BDAA, BAA), Is.True, $"There must be an edge from {BDAA.ID} to {BAA.ID}.");
+            Assert.That(HasEdge(BDAA, BDAA), Is.True, $"There must be an edge from {BDAA.ID} to {BDAA.ID}.");
+            Assert.That(HasEdge(BDAA, BD), Is.True, $"There must be an edge from {BDAA.ID} to {BD.ID}.");
+            Assert.That(HasEdge(C, E), Is.True, $"There must be an edge from {C.ID} to {E.ID}.");
         }
 
         [Test]
@@ -650,13 +650,13 @@ namespace SEE.DataModel.DG
                 Node D = Pendant(subgraph, d) as Node;
                 Node E = Pendant(subgraph, e) as Node;
 
-                Assert.That(HasEdge(A, A));
-                Assert.That(HasEdge(B, B));
-                Assert.That(HasEdge(C, C));
-                Assert.That(HasEdge(D, D));
-                Assert.That(HasEdge(E, E));
-                Assert.That(HasEdge(A, C));
-                Assert.That(HasEdge(B, A));
+                Assert.That(HasEdge(A, A), Is.True, $"There must be an edge from {A.ID} to {A.ID}.");
+                Assert.That(HasEdge(B, B), Is.True, $"There must be an edge from {B.ID} to {B.ID}.");
+                Assert.That(HasEdge(C, C), Is.True, $"There must be an edge from {C.ID} to {C.ID}.");
+                Assert.That(HasEdge(D, D), Is.True, $"There must be an edge from {D.ID} to {D.ID}.");
+                Assert.That(HasEdge(E, E), Is.True, $"There must be an edge from {E.ID} to {E.ID}.");
+                Assert.That(HasEdge(A, C), Is.True, $"There must be an edge from {A.ID} to {C.ID}.");
+                Assert.That(HasEdge(B, A), Is.True, $"There must be an edge from {B.ID} to {A.ID}.");
                 Assert.That(subgraph.EdgeCount, Is.EqualTo(7));
             }
             {
@@ -670,9 +670,9 @@ namespace SEE.DataModel.DG
                 Node D = Pendant(subgraph, d) as Node;
                 Node E = Pendant(subgraph, e) as Node;
 
-                Assert.That(HasEdge(A, A));
-                Assert.That(HasEdge(A, C));
-                Assert.That(HasEdge(B, A));
+                Assert.That(HasEdge(A, A), Is.True, $"There must be an edge from {A.ID} to {A.ID}.");
+                Assert.That(HasEdge(A, C), Is.True, $"There must be an edge from {A.ID} to {C.ID}.");
+                Assert.That(HasEdge(B, A), Is.True, $"There must be an edge from {B.ID} to {A.ID}.");
                 Assert.That(subgraph.EdgeCount, Is.EqualTo(3));
             }
         }

--- a/Assets/SEETests/TestGraph.cs
+++ b/Assets/SEETests/TestGraph.cs
@@ -521,66 +521,40 @@ namespace SEE.DataModel.DG
             Assert.That(Pendant(subgraph, a), Is.Null);
             Assert.That(Pendant(subgraph, b), Is.Null);
             Assert.That(Pendant(subgraph, ba), Is.Null);
-            Node BAA = Pendant(subgraph, baa) as Node;
-            Node BB = Pendant(subgraph, bb) as Node;
+            Node BAA = PendantMustExist(subgraph, baa);
+            Node BB = PendantMustExist(subgraph, bb);
             Assert.That(Pendant(subgraph, bc), Is.Null);
-            Node BCA = Pendant(subgraph, bca) as Node;
+            Node BCA = PendantMustExist(subgraph, bca);
             Assert.That(Pendant(subgraph, bcb), Is.Null);
-            Node BCBA = Pendant(subgraph, bcba) as Node;
-            Node BD = Pendant(subgraph, bd) as Node;
-            Node C = Pendant(subgraph, c) as Node;
+            Node BCBA = PendantMustExist(subgraph, bcba);
+            Node BD = PendantMustExist(subgraph, bd);
+            Node C = PendantMustExist(subgraph, c);
             Assert.That(Pendant(subgraph, d), Is.Null);
-            Node DA = Pendant(subgraph, da) as Node;
-            Node E = Pendant(subgraph, e) as Node;
-            Node BAAAA = Pendant(subgraph, baaaa) as Node;
-            Node BBA = Pendant(subgraph, bba) as Node;
-            Node BCAA = Pendant(subgraph, bcaa) as Node;
-            Node BCAB = Pendant(subgraph, bcab) as Node;
-            Node BDAA = Pendant(subgraph, bdaa) as Node;
+            Node DA = PendantMustExist(subgraph, da);
+            Node E = PendantMustExist(subgraph, e);
+            Node BAAAA = PendantMustExist(subgraph, baaaa);
+            Node BBA = PendantMustExist(subgraph, bba);
+            Node BCAA = PendantMustExist(subgraph, bcaa);
+            Node BCAB = PendantMustExist(subgraph, bcab);
+            Node BDAA = PendantMustExist(subgraph, bdaa);
 
-            Assert.That(BAA, Is.Not.Null, $"{nameof(BAA)} must not be null.");
             Assert.That(BAA.IsRoot(), Is.True, $"{BAA.ID} should be a root.");
-
-            Assert.That(BB, Is.Not.Null, $"{nameof(BB)} must not be null.");
             Assert.That(BB.IsRoot(), Is.True, $"{BB.ID} should be a root.");
-
-            Assert.That(BCA, Is.Not.Null, $"{nameof(BCA)} must not be null.");
             Assert.That(BCA.IsRoot(), Is.True, $"{BCA.ID} should be a root.");
-
-            Assert.That(BCBA, Is.Not.Null, $"{nameof(BCBA)} must not be null.");
             Assert.That(BCBA.IsRoot(), Is.True, $"{BCBA.ID} should be a root.");
-
-            Assert.That(BD, Is.Not.Null, $"{nameof(BD)} must not be null.");
             Assert.That(BD.IsRoot(), Is.True, $"{BD.ID} should be a root.");
-
-            Assert.That(C, Is.Not.Null, $"{nameof(C)} must not be null.");
             Assert.That(C.IsRoot(), Is.True, $"{C.ID} should be a root.");
-            Assert.That(C.IsLeaf(), Is.True, $"{C.ID} should be a leaf.");
-
-            Assert.That(DA, Is.Not.Null, $"{nameof(DA)} must not be null.");
             Assert.That(DA.IsRoot(), Is.True, $"{DA.ID} should be a root.");
-
-            Assert.That(E, Is.Not.Null, $"{nameof(E)} must not be null.");
             Assert.That(E.IsRoot(), Is.True, $"{E.ID} should be a root.");
-            Assert.That(E.IsLeaf(), Is.True, $"{E.ID} should be a leaf.");
 
-            Assert.That(BAAAA, Is.Not.Null, $"{nameof(BAAAA)} must not be null.");
             Assert.That(BAAAA.IsLeaf(), Is.True, $"{BAAAA.ID} should be a leaf.");
-
-            Assert.That(BBA, Is.Not.Null, $"{nameof(BBA)} must not be null.");
             Assert.That(BBA.IsLeaf(), Is.True, $"{BBA.ID} should be a leaf.");
-
-            Assert.That(BCAA, Is.Not.Null, $"{nameof(BCAA)} must not be null.");
             Assert.That(BCAA.IsLeaf(), Is.True, $"{BCAA.ID} should be a leaf.");
-
-            Assert.That(BCAB, Is.Not.Null, $"{nameof(BCAB)} must not be null.");
             Assert.That(BCAB.IsLeaf(), Is.True, $"{BCAB.ID} should be a leaf.");
-
-            Assert.That(BCBA, Is.Not.Null, $"{nameof(BCBA)} must not be null.");
             Assert.That(BCBA.IsLeaf(), Is.True, $"{BCBA.ID} should be a leaf.");
-
-            Assert.That(BDAA, Is.Not.Null, $"{nameof(BDAA)} must not be null.");
             Assert.That(BDAA.IsLeaf(), Is.True, $"{BDAA.ID} should be a leaf.");
+            Assert.That(C.IsLeaf(), Is.True, $"{C.ID} should be a leaf.");
+            Assert.That(E.IsLeaf(), Is.True, $"{E.ID} should be a leaf.");
 
             AssertHasChild(subgraph, baa, baaaa);
             AssertHasChild(subgraph, bb, bba);
@@ -655,11 +629,11 @@ namespace SEE.DataModel.DG
                 Graph subgraph = g.SubgraphByNodeType(new List<string> { RootType }, false);
                 Assert.That(subgraph.NodeCount, Is.EqualTo(g.Nodes().Where(n => n.Type == RootType).Count()));
 
-                Node A = Pendant(subgraph, a) as Node;
-                Node B = Pendant(subgraph, b) as Node;
-                Node C = Pendant(subgraph, c) as Node;
-                Node D = Pendant(subgraph, d) as Node;
-                Node E = Pendant(subgraph, e) as Node;
+                Node A = PendantMustExist(subgraph, a);
+                Node B = PendantMustExist(subgraph, b);
+                Node C = PendantMustExist(subgraph, c);
+                Node D = PendantMustExist(subgraph, d);
+                Node E = PendantMustExist(subgraph, e);
 
                 Assert.That(HasEdge(A, A), Is.True, $"There must be an edge from {A.ID} to {A.ID}.");
                 Assert.That(HasEdge(B, B), Is.True, $"There must be an edge from {B.ID} to {B.ID}.");
@@ -675,11 +649,11 @@ namespace SEE.DataModel.DG
                 Graph subgraph = g.SubgraphByNodeType(new List<string> { RootType }, true);
                 Assert.That(subgraph.NodeCount, Is.EqualTo(g.Nodes().Where(n => n.Type == RootType).Count()));
 
-                Node A = Pendant(subgraph, a) as Node;
-                Node B = Pendant(subgraph, b) as Node;
-                Node C = Pendant(subgraph, c) as Node;
-                Node D = Pendant(subgraph, d) as Node;
-                Node E = Pendant(subgraph, e) as Node;
+                Node A = PendantMustExist(subgraph, a);
+                Node B = PendantMustExist(subgraph, b);
+                Node C = PendantMustExist(subgraph, c);
+                Node D = PendantMustExist(subgraph, d);
+                Node E = PendantMustExist(subgraph, e);
 
                 Assert.That(HasEdge(A, A), Is.True, $"There must be an edge from {A.ID} to {A.ID}.");
                 Assert.That(HasEdge(A, C), Is.True, $"There must be an edge from {A.ID} to {C.ID}.");

--- a/Assets/SEETests/TestGraph.cs
+++ b/Assets/SEETests/TestGraph.cs
@@ -538,38 +538,49 @@ namespace SEE.DataModel.DG
             Node BCAB = Pendant(subgraph, bcab) as Node;
             Node BDAA = Pendant(subgraph, bdaa) as Node;
 
-            Assert.That(BAA.IsRoot, Is.True,
-                        $"{BAA.ID} should be a root.");
-            Assert.That(BB.IsRoot, Is.True,
-                        $"{BB.ID} should be a root.");
-            Assert.That(BCA.IsRoot, Is.True,
-                        $"{BCA.ID} should be a root.");
-            Assert.That(BCBA.IsRoot, Is.True,
-                        $"{BCBA.ID} should be a root.");
-            Assert.That(BD.IsRoot, Is.True,
-                        $"{BD.ID} should be a root.");
-            Assert.That(C.IsRoot, Is.True,
-                        $"{C.ID} should be a root.");
-            Assert.That(DA.IsRoot, Is.True,
-                        $"{DA.ID} should be a root.");
-            Assert.That(E.IsRoot, Is.True,
-                        $"{E.ID} should be a root.");
-            Assert.That(BAAAA.IsLeaf, Is.True,
-                        $"{BAAAA.ID} should be a leaf.");
-            Assert.That(BBA.IsLeaf, Is.True,
-                        $"{BBA.ID} should be a leaf.");
-            Assert.That(BCAA.IsLeaf, Is.True,
-                        $"{BCAA.ID} should be a leaf.");
-            Assert.That(BCAB.IsLeaf, Is.True,
-                        $"{BCAB.ID} should be a leaf.");
-            Assert.That(BCBA.IsLeaf, Is.True,
-                        $"{BCBA.ID} should be a leaf.");
-            Assert.That(BDAA.IsLeaf, Is.True,
-                        $"{BDAA.ID} should be a leaf.");
-            Assert.That(C.IsLeaf, Is.True,
-                        $"{C.ID} should be a leaf.");
-            Assert.That(E.IsLeaf, Is.True,
-                        $"{E.ID} should be a leaf.");
+            Assert.That(BAA, Is.Not.Null, $"{nameof(BAA)} must not be null.");
+            Assert.That(BAA.IsRoot(), Is.True, $"{BAA.ID} should be a root.");
+
+            Assert.That(BB, Is.Not.Null, $"{nameof(BB)} must not be null.");
+            Assert.That(BB.IsRoot(), Is.True, $"{BB.ID} should be a root.");
+
+            Assert.That(BCA, Is.Not.Null, $"{nameof(BCA)} must not be null.");
+            Assert.That(BCA.IsRoot(), Is.True, $"{BCA.ID} should be a root.");
+
+            Assert.That(BCBA, Is.Not.Null, $"{nameof(BCBA)} must not be null.");
+            Assert.That(BCBA.IsRoot(), Is.True, $"{BCBA.ID} should be a root.");
+
+            Assert.That(BD, Is.Not.Null, $"{nameof(BD)} must not be null.");
+            Assert.That(BD.IsRoot(), Is.True, $"{BD.ID} should be a root.");
+
+            Assert.That(C, Is.Not.Null, $"{nameof(C)} must not be null.");
+            Assert.That(C.IsRoot(), Is.True, $"{C.ID} should be a root.");
+            Assert.That(C.IsLeaf(), Is.True, $"{C.ID} should be a leaf.");
+
+            Assert.That(DA, Is.Not.Null, $"{nameof(DA)} must not be null.");
+            Assert.That(DA.IsRoot(), Is.True, $"{DA.ID} should be a root.");
+
+            Assert.That(E, Is.Not.Null, $"{nameof(E)} must not be null.");
+            Assert.That(E.IsRoot(), Is.True, $"{E.ID} should be a root.");
+            Assert.That(E.IsLeaf(), Is.True, $"{E.ID} should be a leaf.");
+
+            Assert.That(BAAAA, Is.Not.Null, $"{nameof(BAAAA)} must not be null.");
+            Assert.That(BAAAA.IsLeaf(), Is.True, $"{BAAAA.ID} should be a leaf.");
+
+            Assert.That(BBA, Is.Not.Null, $"{nameof(BBA)} must not be null.");
+            Assert.That(BBA.IsLeaf(), Is.True, $"{BBA.ID} should be a leaf.");
+
+            Assert.That(BCAA, Is.Not.Null, $"{nameof(BCAA)} must not be null.");
+            Assert.That(BCAA.IsLeaf(), Is.True, $"{BCAA.ID} should be a leaf.");
+
+            Assert.That(BCAB, Is.Not.Null, $"{nameof(BCAB)} must not be null.");
+            Assert.That(BCAB.IsLeaf(), Is.True, $"{BCAB.ID} should be a leaf.");
+
+            Assert.That(BCBA, Is.Not.Null, $"{nameof(BCBA)} must not be null.");
+            Assert.That(BCBA.IsLeaf(), Is.True, $"{BCBA.ID} should be a leaf.");
+
+            Assert.That(BDAA, Is.Not.Null, $"{nameof(BDAA)} must not be null.");
+            Assert.That(BDAA.IsLeaf(), Is.True, $"{BDAA.ID} should be a leaf.");
 
             AssertHasChild(subgraph, baa, baaaa);
             AssertHasChild(subgraph, bb, bba);

--- a/Assets/SEETests/TestGraph.cs
+++ b/Assets/SEETests/TestGraph.cs
@@ -676,7 +676,7 @@ namespace SEE.DataModel.DG
             Assert.AreEqual(0, g.EdgeCount);
 
             subgraph.Restore();
-            Assert.AreEqual(g, a.ItsGraph);
+            Assert.That(a.ItsGraph, Is.SameAs(g));
             Assert.AreEqual(1, g.NodeCount);
             Assert.AreEqual(0, g.EdgeCount);
         }
@@ -698,8 +698,8 @@ namespace SEE.DataModel.DG
             Assert.AreEqual(0, g.EdgeCount);
 
             subgraph.Restore();
-            Assert.AreEqual(g, a.ItsGraph);
-            Assert.AreEqual(g, e.ItsGraph);
+            Assert.That(a.ItsGraph, Is.SameAs(g));
+            Assert.That(e.ItsGraph, Is.SameAs(g));
             Assert.AreEqual(1, g.NodeCount);
             Assert.AreEqual(1, g.EdgeCount);
         }
@@ -736,16 +736,16 @@ namespace SEE.DataModel.DG
             SubgraphMemento subgraph = c.DeleteTree();
 
             // a and b are still in the graph, but all other nodes are removed
-            Assert.AreEqual(g, a.ItsGraph);
-            Assert.AreEqual(g, b.ItsGraph);
+            Assert.That(a.ItsGraph, Is.SameAs(g));
+            Assert.That(b.ItsGraph, Is.SameAs(g));
             foreach (Node node in subgraphNodes)
             {
                 Assert.IsNull(node.ItsGraph);
             }
 
             // e1 and e2 are still in the graph, but all other edges are removed
-            Assert.AreEqual(g, e1.ItsGraph);
-            Assert.AreEqual(g, e2.ItsGraph);
+            Assert.That(e1.ItsGraph, Is.SameAs(g));
+            Assert.That(e2.ItsGraph, Is.SameAs(g));
             foreach (Edge edge in subgraphEdges)
             {
                 Assert.IsNull(edge.ItsGraph);
@@ -755,18 +755,18 @@ namespace SEE.DataModel.DG
             Assert.AreEqual(2, g.EdgeCount);
 
             subgraph.Restore();
-            Assert.AreEqual(g, a.ItsGraph);
-            Assert.AreEqual(g, b.ItsGraph);
+            Assert.That(a.ItsGraph, Is.SameAs(g));
+            Assert.That(b.ItsGraph, Is.SameAs(g));
             foreach (Node node in subgraphNodes)
             {
-                Assert.AreEqual(g, node.ItsGraph);
+                Assert.That(node.ItsGraph, Is.SameAs(g));
             }
 
-            Assert.AreEqual(g, e1.ItsGraph);
-            Assert.AreEqual(g, e2.ItsGraph);
+            Assert.That(e1.ItsGraph, Is.SameAs(g));
+            Assert.That(e2.ItsGraph, Is.SameAs(g));
             foreach (Edge edge in subgraphEdges)
             {
-                Assert.AreEqual(g, edge.ItsGraph);
+                Assert.That(edge.ItsGraph, Is.SameAs(g));
             }
 
             Assert.AreEqual(subgraphNodes.Count + 2, g.NodeCount);

--- a/Assets/SEETests/TestGraphBase.cs
+++ b/Assets/SEETests/TestGraphBase.cs
@@ -122,7 +122,8 @@ namespace SEE.DataModel.DG
         /// <param name="child">child node</param>
         protected void AssertHasChild(Graph graph, Node parent, Node child)
         {
-            Assert.AreSame(Pendant(graph, parent), (Pendant(graph, child) as Node).Parent);
+            Assert.That((Pendant(graph, child) as Node).Parent, Is.SameAs(Pendant(graph, parent)),
+                        $"{child.ID} must be a child of {parent.ID} in graph {graph.Name}.");
         }
 
         /// <summary>

--- a/Assets/SEETests/TestGraphBase.cs
+++ b/Assets/SEETests/TestGraphBase.cs
@@ -99,6 +99,24 @@ namespace SEE.DataModel.DG
         protected GraphElement Pendant(Graph graph, GraphElement node) => node is Node ? graph.GetNode(node.ID) : graph.GetEdge(node.ID);
 
         /// <summary>
+        /// Returns the <see cref="Pendant"/> of <paramref name="node"/> in <paramref name="graph"/>,
+        /// asserting that it exists.
+        ///
+        /// Use this instead of <see cref="Pendant"/> wherever the pendant is expected to exist.
+        /// A missing pendant is then reported as a failing assertion naming the node, rather
+        /// than as a <see cref="NullReferenceException"/> at the next dereference.
+        /// </summary>
+        /// <param name="graph">graph where to look up the ID of <paramref name="node"/></param>
+        /// <param name="node">node whose counterpart in <paramref name="graph"/> is requested</param>
+        /// <returns>node in <paramref name="graph"/> that has the same ID as <paramref name="node"/></returns>
+        protected Node PendantMustExist(Graph graph, Node node)
+        {
+            GraphElement pendant = Pendant(graph, node);
+            Assert.That(pendant, Is.Not.Null, $"Graph {graph.Name} has no node {node.ID}.");
+            return (Node)pendant;
+        }
+
+        /// <summary>
         /// Returns true if <paramref name="source"/> has an outgoing edge with given <paramref name="target"/>
         /// and <paramref name="edgeType"/>.
         /// </summary>
@@ -122,7 +140,7 @@ namespace SEE.DataModel.DG
         /// <param name="child">child node</param>
         protected void AssertHasChild(Graph graph, Node parent, Node child)
         {
-            Assert.That((Pendant(graph, child) as Node).Parent, Is.SameAs(Pendant(graph, parent)),
+            Assert.That(PendantMustExist(graph, child).Parent, Is.SameAs(PendantMustExist(graph, parent)),
                         $"{child.ID} must be a child of {parent.ID} in graph {graph.Name}.");
         }
 

--- a/Assets/SEETests/TestGraphCloning.cs
+++ b/Assets/SEETests/TestGraphCloning.cs
@@ -28,18 +28,18 @@ namespace SEE.DataModel.DG
             graph.AddNode(original);
 
             Node clone = (Node)original.Clone();
-            Assert.That(clone.Type == original.Type);
-            Assert.That(clone.ID == original.ID);
-            Assert.That(clone.SourceName == original.SourceName);
-            Assert.That(clone.GetFloat("float") == original.GetFloat("float"));
-            Assert.That(clone.GetInt("int") == original.GetInt("int"));
-            Assert.That(clone.GetString("string") == original.GetString("string"));
-            Assert.That(clone.HasToggle("toggle"));
+            Assert.That(clone.Type, Is.EqualTo(original.Type));
+            Assert.That(clone.ID, Is.EqualTo(original.ID));
+            Assert.That(clone.SourceName, Is.EqualTo(original.SourceName));
+            Assert.That(clone.GetFloat("float"), Is.EqualTo(original.GetFloat("float")));
+            Assert.That(clone.GetInt("int"), Is.EqualTo(original.GetInt("int")));
+            Assert.That(clone.GetString("string"), Is.EqualTo(original.GetString("string")));
+            Assert.That(clone.HasToggle("toggle"), Is.True, "The toggle must be cloned.");
             // Note: Hierarchy information (parent, children, level) is cloned only when a
             // graph is cloned.
-            Assert.That(clone.Level == 0);
+            Assert.That(clone.Level, Is.EqualTo(0));
             Assert.That(clone.Parent, Is.Null);
-            Assert.That(clone.Children().Count == 0);
+            Assert.That(clone.Children(), Is.Empty);
             // cloned nodes do not yet belong to any graph
             Assert.That(clone.ItsGraph, Is.Null);
         }
@@ -72,14 +72,14 @@ namespace SEE.DataModel.DG
             graph.AddEdge(original);
 
             Edge clone = (Edge)original.Clone();
-            Assert.That(clone.Type == original.Type);
-            Assert.That(clone.GetFloat("float") == original.GetFloat("float"));
-            Assert.That(clone.GetInt("int") == original.GetInt("int"));
-            Assert.That(clone.GetString("string") == original.GetString("string"));
-            Assert.That(clone.HasToggle("toggle"));
+            Assert.That(clone.Type, Is.EqualTo(original.Type));
+            Assert.That(clone.GetFloat("float"), Is.EqualTo(original.GetFloat("float")));
+            Assert.That(clone.GetInt("int"), Is.EqualTo(original.GetInt("int")));
+            Assert.That(clone.GetString("string"), Is.EqualTo(original.GetString("string")));
+            Assert.That(clone.HasToggle("toggle"), Is.True, "The toggle must be cloned.");
             // Note: Source and target of an edge should be cloned (shallow copy), too.
-            Assert.That(clone.Source == original.Source);
-            Assert.That(clone.Target == original.Target);
+            Assert.That(clone.Source, Is.SameAs(original.Source));
+            Assert.That(clone.Target, Is.SameAs(original.Target));
             // cloned edges do not yet belong to any graph
             Assert.That(clone.ItsGraph, Is.Null);
         }
@@ -127,23 +127,23 @@ namespace SEE.DataModel.DG
             n1_c1.AddChild(n1_c1_c2);
 
             Graph clone = (Graph)original.Clone();
-            Assert.That(clone.Path == original.Path);
-            Assert.That(clone.Name == original.Name);
-            Assert.That(clone.NodeCount == original.NodeCount);
-            Assert.That(clone.EdgeCount == original.EdgeCount);
+            Assert.That(clone.Path, Is.EqualTo(original.Path));
+            Assert.That(clone.Name, Is.EqualTo(original.Name));
+            Assert.That(clone.NodeCount, Is.EqualTo(original.NodeCount));
+            Assert.That(clone.EdgeCount, Is.EqualTo(original.EdgeCount));
 
             // all cloned nodes must be in the cloned graph
             foreach (Node node in clone.Nodes())
             {
-                Assert.AreEqual(clone, node.ItsGraph);
+                Assert.That(node.ItsGraph, Is.EqualTo(clone));
             }
             // all cloned edges must be in the cloned graph (and their
             // source and target, too)
             foreach (Edge edge in clone.Edges())
             {
-                Assert.AreEqual(clone, edge.ItsGraph);
-                Assert.AreEqual(clone, edge.Source.ItsGraph);
-                Assert.AreEqual(clone, edge.Target.ItsGraph);
+                Assert.That(edge.ItsGraph, Is.EqualTo(clone));
+                Assert.That(edge.Source.ItsGraph, Is.EqualTo(clone));
+                Assert.That(edge.Target.ItsGraph, Is.EqualTo(clone));
             }
             CompareHierarchy(original, clone);
         }
@@ -158,31 +158,29 @@ namespace SEE.DataModel.DG
                 }
                 else
                 {
-                    Assert.Fail();
+                    Assert.Fail($"Root {root.ID} of the original graph is missing in the clone.");
                 }
             }
         }
 
         private void CompareHierarchy(Node node, Graph clone, Node clonedNode)
         {
-            Assert.That(node.ID == clonedNode.ID,
-                        "Linknames differ: " + node.ID + " != " + clonedNode.ID);
-            Assert.That(node.NumberOfChildren() == clonedNode.NumberOfChildren());
-            Assert.That(node.Level == clonedNode.Level,
-                        "levels differ between correspondings nodes with linkname "
-                        + node.ID + ": "
-                        + node.Level + " (expected) != " + clonedNode.Level + " (actual)");
+            Assert.That(clonedNode.ID, Is.EqualTo(node.ID), "Linknames differ.");
+            Assert.That(clonedNode.NumberOfChildren(), Is.EqualTo(node.NumberOfChildren()),
+                        $"Number of children differs for node {node.ID}.");
+            Assert.That(clonedNode.Level, Is.EqualTo(node.Level),
+                        $"Levels differ between corresponding nodes with linkname {node.ID}.");
 
             if (node.IsRoot())
             {
-                Assert.That(clonedNode.IsRoot());
+                Assert.That(clonedNode.IsRoot(), Is.True,
+                            $"{clonedNode} should be a root, because its corresponding node {node} is one.");
             }
             else
             {
-                Assert.That(!clonedNode.IsRoot(),
-                            clonedNode + " should not be a root. Corresponding node in original graph: "
-                                       + node);
-                Assert.That(node.Parent.ID == clonedNode.Parent.ID);
+                Assert.That(clonedNode.IsRoot(), Is.False,
+                            $"{clonedNode} should not be a root. Corresponding node in original graph: {node}");
+                Assert.That(clonedNode.Parent.ID, Is.EqualTo(node.Parent.ID));
             }
 
             foreach (Node nodeChild in node.Children())
@@ -193,7 +191,7 @@ namespace SEE.DataModel.DG
                 }
                 else
                 {
-                    Assert.Fail();
+                    Assert.Fail($"Child {nodeChild.ID} of node {node.ID} is missing in the clone.");
                 }
             }
         }

--- a/Assets/SEETests/TestGraphCloning.cs
+++ b/Assets/SEETests/TestGraphCloning.cs
@@ -132,18 +132,23 @@ namespace SEE.DataModel.DG
             Assert.That(clone.NodeCount, Is.EqualTo(original.NodeCount));
             Assert.That(clone.EdgeCount, Is.EqualTo(original.EdgeCount));
 
-            // all cloned nodes must be in the cloned graph
+            // All cloned nodes must be in the cloned graph.
+            // Note: The graph is compared by identity (Is.SameAs), not by equality
+            // (Is.EqualTo). Graph.Equals considers only Name and Path, both of which a
+            // clone shares with its original, hence Is.EqualTo would hold even for an
+            // element that still belonged to the original graph. That is precisely the
+            // defect these assertions are meant to detect, so identity is required here.
             foreach (Node node in clone.Nodes())
             {
-                Assert.That(node.ItsGraph, Is.EqualTo(clone));
+                Assert.That(node.ItsGraph, Is.SameAs(clone));
             }
-            // all cloned edges must be in the cloned graph (and their
-            // source and target, too)
+            // All cloned edges must be in the cloned graph (and their
+            // source and target, too).
             foreach (Edge edge in clone.Edges())
             {
-                Assert.That(edge.ItsGraph, Is.EqualTo(clone));
-                Assert.That(edge.Source.ItsGraph, Is.EqualTo(clone));
-                Assert.That(edge.Target.ItsGraph, Is.EqualTo(clone));
+                Assert.That(edge.ItsGraph, Is.SameAs(clone));
+                Assert.That(edge.Source.ItsGraph, Is.SameAs(clone));
+                Assert.That(edge.Target.ItsGraph, Is.SameAs(clone));
             }
             CompareHierarchy(original, clone);
         }

--- a/Assets/SEETests/TestGraphCloning.cs
+++ b/Assets/SEETests/TestGraphCloning.cs
@@ -132,12 +132,13 @@ namespace SEE.DataModel.DG
             Assert.That(clone.NodeCount, Is.EqualTo(original.NodeCount));
             Assert.That(clone.EdgeCount, Is.EqualTo(original.EdgeCount));
 
-            // All cloned nodes must be in the cloned graph.
-            // Note: The graph is compared by identity (Is.SameAs), not by equality
-            // (Is.EqualTo). Graph.Equals considers only Name and Path, both of which a
-            // clone shares with its original, hence Is.EqualTo would hold even for an
-            // element that still belonged to the original graph. That is precisely the
-            // defect these assertions are meant to detect, so identity is required here.
+            /// All cloned nodes must be in the cloned graph.
+            /// Note: The graph is compared by identity (Is.SameAs), not by equality
+            /// (Is.EqualTo). <see cref="Graph.Equals"/> considers only Name and Path (beyond
+            /// the type of the graph), both of which a clone shares with its original,
+            /// hence Is.EqualTo would hold even for an element that still belonged to the
+            /// original graph. That is precisely the defect these assertions are meant to
+            /// detect, so identity is required here.
             foreach (Node node in clone.Nodes())
             {
                 Assert.That(node.ItsGraph, Is.SameAs(clone));

--- a/Assets/SEETests/TestGraphDiff.cs
+++ b/Assets/SEETests/TestGraphDiff.cs
@@ -23,10 +23,10 @@ namespace SEE.DataModel.DG
               out ISet<Node> removed,
               out ISet<Node> changed,
               out ISet<Node> equal);
-            Assert.AreEqual(0, added.Count);
-            Assert.AreEqual(0, removed.Count);
-            Assert.AreEqual(0, changed.Count);
-            Assert.AreEqual(0, equal.Count);
+            Assert.That(added, Is.Empty);
+            Assert.That(removed, Is.Empty);
+            Assert.That(changed, Is.Empty);
+            Assert.That(equal, Is.Empty);
         }
 
         /// <summary>
@@ -381,11 +381,9 @@ namespace SEE.DataModel.DG
         /// <param name="actual">actual value</param>
         private static void AreEqual<T>(ISet<T> expected, ISet<T> actual) where T : GraphElement
         {
-            Assert.AreEqual(expected.Count, actual.Count);
-            foreach (GraphElement element in expected)
-            {
-                Assert.IsTrue(actual.Contains(element));
-            }
+            // Both are sets, so equal size plus containment of every expected
+            // element is exactly set equality, which is what Is.EquivalentTo checks.
+            Assert.That(actual, Is.EquivalentTo(expected));
         }
 
         /// <summary>
@@ -423,10 +421,10 @@ namespace SEE.DataModel.DG
                               out ISet<Node> removed,
                               out ISet<Node> changed,
                               out ISet<Node> equal);
-                Assert.AreEqual(0, added.Count);
-                Assert.AreEqual(0, removed.Count);
-                Assert.AreEqual(0, changed.Count);
-                Assert.AreEqual(0, equal.Count);
+                Assert.That(added, Is.Empty);
+                Assert.That(removed, Is.Empty);
+                Assert.That(changed, Is.Empty);
+                Assert.That(equal, Is.Empty);
             }
 
             // Edge comparison.
@@ -440,10 +438,10 @@ namespace SEE.DataModel.DG
                               out ISet<Edge> removed,
                               out ISet<Edge> changed,
                               out ISet<Edge> equal);
-                Assert.AreEqual(0, added.Count);
-                Assert.AreEqual(0, removed.Count);
-                Assert.AreEqual(0, changed.Count);
-                Assert.AreEqual(0, equal.Count);
+                Assert.That(added, Is.Empty);
+                Assert.That(removed, Is.Empty);
+                Assert.That(changed, Is.Empty);
+                Assert.That(equal, Is.Empty);
             }
         }
     }

--- a/Assets/SEETests/TestGraphIO.cs
+++ b/Assets/SEETests/TestGraphIO.cs
@@ -157,6 +157,7 @@ namespace SEE.DataModel.DG.IO
         /// Writes inGraph to F'.
         /// Reads backupGraph from F'.
         /// Compares inGraph and backupGraph.
+        /// Compares the content of outGraph and backupGraph.
         /// </summary>
         /// <param name="basename">basename of the filename for storing graphs</param>
         /// <param name="outGraph">the initial graph to be written</param>
@@ -197,12 +198,54 @@ namespace SEE.DataModel.DG.IO
                 // do not compare the content of the graphs.
                 Assert.That(inGraph, Is.EqualTo(outGraph), "Name and path of the graph read.");
                 Assert.That(inGraph, Is.EqualTo(backupGraph), "Name and path of the backup graph.");
+
+                // The content of the graphs, that is, their nodes and edges along with
+                // their attributes, must be the same, too.
+                AssertNoDifference(outGraph, backupGraph);
             }
             finally
             {
                 FileIO.DeleteIfExists(path.Path);
                 FileIO.DeleteIfExists(backupPath.Path);
             }
+        }
+
+        /// <summary>
+        /// Asserts that <paramref name="newGraph"/> has no differences relative to
+        /// <paramref name="oldGraph"/>, that is, that both graphs have the same nodes
+        /// and edges (identified by their IDs) and that these have the same attributes.
+        /// </summary>
+        /// <param name="oldGraph">the baseline graph</param>
+        /// <param name="newGraph">the graph to be compared against <paramref name="oldGraph"/></param>
+        private static void AssertNoDifference(Graph oldGraph, Graph newGraph)
+        {
+            IGraphElementDiff attributeDiff = GraphExtensions.AttributeDiff(oldGraph, newGraph);
+
+            newGraph.Diff(oldGraph,
+                          g => g.Nodes(),
+                          (g, id) => g.GetNode(id),
+                          attributeDiff,
+                          new NodeEqualityComparer(),
+                          out ISet<Node> addedNodes,
+                          out ISet<Node> removedNodes,
+                          out ISet<Node> changedNodes,
+                          out _);
+            Assert.That(addedNodes, Is.Empty, "Nodes only in the new graph.");
+            Assert.That(removedNodes, Is.Empty, "Nodes only in the old graph.");
+            Assert.That(changedNodes, Is.Empty, "Nodes with different attributes.");
+
+            newGraph.Diff(oldGraph,
+                          g => g.Edges(),
+                          (g, id) => g.GetEdge(id),
+                          attributeDiff,
+                          new EdgeEqualityComparer(),
+                          out ISet<Edge> addedEdges,
+                          out ISet<Edge> removedEdges,
+                          out ISet<Edge> changedEdges,
+                          out _);
+            Assert.That(addedEdges, Is.Empty, "Edges only in the new graph.");
+            Assert.That(removedEdges, Is.Empty, "Edges only in the old graph.");
+            Assert.That(changedEdges, Is.Empty, "Edges with different attributes.");
         }
 
         private static async UniTask<Graph> LoadGraphAsync(DataPath path)

--- a/Assets/SEETests/TestGraphIO.cs
+++ b/Assets/SEETests/TestGraphIO.cs
@@ -180,7 +180,7 @@ namespace SEE.DataModel.DG.IO
 
                 // Read the saved outGraph again
                 Graph inGraph = await LoadGraphAsync(path);
-                Assert.AreEqual(path.Path, inGraph.Path);
+                Assert.That(inGraph.Path, Is.EqualTo(path.Path));
 
                 // Write the loaded saved initial graph again as a backup
                 GraphWriter.Save(backupPath.Path, inGraph, hierarchicalEdgeType);
@@ -188,12 +188,15 @@ namespace SEE.DataModel.DG.IO
                 // Read the backup graph again
                 Graph backupGraph = await LoadGraphAsync(backupPath);
                 // The path of backupGraph will be backupFilename.
-                Assert.AreEqual(backupPath.Path, backupGraph.Path);
+                Assert.That(backupGraph.Path, Is.EqualTo(backupPath.Path));
                 // For the comparison, we need to reset the path.
                 backupGraph.Path = inGraph.Path = outGraph.Path;
 
-                Assert.AreEqual(outGraph, inGraph);
-                Assert.AreEqual(backupGraph, inGraph);
+                // Note that Graph.Equals compares only the type, Name and Path of a graph.
+                // Because the paths have just been made equal above, these two assertions
+                // do not compare the content of the graphs.
+                Assert.That(inGraph, Is.EqualTo(outGraph), "Name and path of the graph read.");
+                Assert.That(inGraph, Is.EqualTo(backupGraph), "Name and path of the backup graph.");
             }
             finally
             {

--- a/Assets/SEETests/TestGraphProviderIO.cs
+++ b/Assets/SEETests/TestGraphProviderIO.cs
@@ -17,9 +17,9 @@ namespace SEE.GraphProviders
     {
         public static void AreEqual(MultiGraphPipelineProvider expected, MultiGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             MultiGraphPipelineProvider graphPipelineLoaded = actual as MultiGraphPipelineProvider;
-            Assert.AreEqual(expected.Pipeline.Count, graphPipelineLoaded.Pipeline.Count);
+            Assert.That(graphPipelineLoaded.Pipeline.Count, Is.EqualTo(expected.Pipeline.Count));
             for (int i = 0; i < expected.Pipeline.Count; i++)
             {
                 AreEqual(expected.Pipeline[i], graphPipelineLoaded.Pipeline[i]);
@@ -35,7 +35,7 @@ namespace SEE.GraphProviders
         /// <exception cref="System.NotImplementedException"></exception>
         public static void AreEqual(MultiGraphProvider expected, MultiGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             if (expected is GXLEvolutionGraphProvider gxlEvolution)
             {
                 AreEqualGXLEvolutionProviders(gxlEvolution, actual);
@@ -48,26 +48,26 @@ namespace SEE.GraphProviders
 
         private static void AreEqualGXLEvolutionProviders(GXLEvolutionGraphProvider expected, MultiGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             GXLEvolutionGraphProvider gxlLoaded = actual as GXLEvolutionGraphProvider;
             AreEqual(expected.GXLDirectory, gxlLoaded.GXLDirectory);
-            Assert.AreEqual(expected.MaxRevisionsToLoad, gxlLoaded.MaxRevisionsToLoad);
+            Assert.That(gxlLoaded.MaxRevisionsToLoad, Is.EqualTo(expected.MaxRevisionsToLoad));
         }
 
         private static void AreEqualGitEvolutionProviders(GitEvolutionGraphProvider expected, MultiGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             GitEvolutionGraphProvider gitLoaded = actual as GitEvolutionGraphProvider;
-            Assert.AreEqual(expected.Date, gitLoaded.Date);
+            Assert.That(gitLoaded.Date, Is.EqualTo(expected.Date));
             AreEqual(expected.GitRepository.RepositoryPath, gitLoaded.GitRepository.RepositoryPath);
             AreEqualFilters(expected.GitRepository.VCSFilter, gitLoaded.GitRepository.VCSFilter);
         }
 
         private static void AreEqualFilters(SEE.VCS.Filter expected, SEE.VCS.Filter actual)
         {
-            Assert.AreEqual(expected.Globbing, actual.Globbing);
-            Assert.AreEqual(expected.RepositoryPaths, actual.RepositoryPaths);
-            Assert.AreEqual(expected.Branches, actual.Branches);
+            Assert.That(actual.Globbing, Is.EqualTo(expected.Globbing));
+            Assert.That(actual.RepositoryPaths, Is.EqualTo(expected.RepositoryPaths));
+            Assert.That(actual.Branches, Is.EqualTo(expected.Branches));
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace SEE.GraphProviders
         /// <exception cref="System.NotImplementedException"></exception>
         public static void AreEqual(SingleGraphProvider expected, SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             if (expected is GXLSingleGraphProvider gXLGraphProvider)
             {
                 AreEqualGXLProviders(gXLGraphProvider, actual);
@@ -163,7 +163,7 @@ namespace SEE.GraphProviders
 
         private static void AreEqualGXLProviders(GXLSingleGraphProvider expected, SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             GXLSingleGraphProvider gxlSingleLoaded = actual as GXLSingleGraphProvider;
             AreEqual(expected.Path, gxlSingleLoaded.Path);
         }
@@ -190,7 +190,7 @@ namespace SEE.GraphProviders
 
         private static void AreEqualCSVProviders(CSVGraphProvider expected, SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             CSVGraphProvider gxlLoaded = actual as CSVGraphProvider;
             AreEqual(expected.Path, gxlLoaded.Path);
         }
@@ -217,7 +217,7 @@ namespace SEE.GraphProviders
 
         private static void AreEqualJaCoCoGraphProviders(JaCoCoGraphProvider expected, SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             JaCoCoGraphProvider loadedProvider = actual as JaCoCoGraphProvider;
             AreEqual(expected.Path, loadedProvider.Path);
         }
@@ -283,9 +283,9 @@ namespace SEE.GraphProviders
         private static void AreEqualSinglePipelineProviders(SingleGraphPipelineProvider expected,
                                                             SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             SingleGraphPipelineProvider graphPipelineLoaded = actual as SingleGraphPipelineProvider;
-            Assert.AreEqual(expected.Pipeline.Count, graphPipelineLoaded.Pipeline.Count);
+            Assert.That(graphPipelineLoaded.Pipeline.Count, Is.EqualTo(expected.Pipeline.Count));
             for (int i = 0; i < expected.Pipeline.Count; i++)
             {
                 AreEqual(expected.Pipeline[i], graphPipelineLoaded.Pipeline[i]);
@@ -315,9 +315,9 @@ namespace SEE.GraphProviders
         private void AreEqualAllBranchGitSingleProvider(GitBranchesGraphProvider expected,
                                                         SingleGraphProvider actual)
         {
-            Assert.AreEqual(expected.GetType(), actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             GitBranchesGraphProvider gitBranchesLoaded = actual as GitBranchesGraphProvider;
-            Assert.AreEqual(gitBranchesLoaded.SimplifyGraph, expected.SimplifyGraph);
+            Assert.That(gitBranchesLoaded.SimplifyGraph, Is.EqualTo(expected.SimplifyGraph));
         }
 
         private GitBranchesGraphProvider GetAllBranchGitSingleProvider()
@@ -366,7 +366,7 @@ namespace SEE.GraphProviders
 
         private static void AreEqualReflexionGraphProviders(ReflexionGraphProvider expected, SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             ReflexionGraphProvider reflexionLoaded = actual as ReflexionGraphProvider;
             AreEqual(expected.Architecture, reflexionLoaded.Architecture);
             AreEqual(expected.Implementation, reflexionLoaded.Implementation);
@@ -398,7 +398,7 @@ namespace SEE.GraphProviders
 
         private static void AreEqualDiffMergeGraphProviders(MergeDiffGraphProvider expected, SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             MergeDiffGraphProvider loadedProvider = actual as MergeDiffGraphProvider;
             AreEqual(expected.OldGraph, loadedProvider.OldGraph);
         }
@@ -416,28 +416,29 @@ namespace SEE.GraphProviders
 
         private void AreEqualVCSGraphProviders(BetweenCommitsGraphProvider expected, SingleGraphProvider actual)
         {
-            Assert.IsTrue(expected.GetType() == actual.GetType());
+            Assert.That(actual, Is.TypeOf(expected.GetType()));
             BetweenCommitsGraphProvider loadedProvider = actual as BetweenCommitsGraphProvider;
             AreEqual(expected.GitRepository, loadedProvider.GitRepository);
-            Assert.AreEqual(expected.CommitID, loadedProvider.CommitID);
-            Assert.AreEqual(expected.BaselineCommitID, loadedProvider.BaselineCommitID);
+            Assert.That(loadedProvider.CommitID, Is.EqualTo(expected.CommitID));
+            Assert.That(loadedProvider.BaselineCommitID, Is.EqualTo(expected.BaselineCommitID));
         }
 
         private static void AreEqual(GitRepository expected, GitRepository actual)
         {
-            Assert.IsNotNull(expected);
-            Assert.IsNotNull(actual);
+            Assert.That(expected, Is.Not.Null);
+            Assert.That(actual, Is.Not.Null);
             AreEqual(expected.RepositoryPath, actual.RepositoryPath);
             AreEqualFilters(expected.VCSFilter, actual.VCSFilter);
         }
 
         private void AreEqualDictionaries(IDictionary<string, bool> expected, IDictionary<string, bool> actual)
         {
-            Assert.AreEqual(expected.Count, actual.Count);
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
             foreach (var kv in expected)
             {
-                Assert.IsTrue(actual.TryGetValue(kv.Key, out bool value));
-                Assert.AreEqual(kv.Value, value);
+                Assert.That(actual.TryGetValue(kv.Key, out bool value), Is.True,
+                            $"There is no entry for key {kv.Key} in the actual dictionary.");
+                Assert.That(value, Is.EqualTo(kv.Value), $"Values differ for key {kv.Key}.");
             }
         }
 
@@ -464,7 +465,7 @@ namespace SEE.GraphProviders
         {
             using ConfigReader stream = new(filename);
             SingleGraphProvider loaded = SingleGraphProvider.Restore(stream.Read(), providerLabel);
-            Assert.IsNotNull(loaded);
+            Assert.That(loaded, Is.Not.Null);
             return loaded;
         }
 
@@ -490,7 +491,7 @@ namespace SEE.GraphProviders
         {
             using ConfigReader stream = new(filename);
             MultiGraphProvider loaded = MultiGraphProvider.Restore(stream.Read(), providerLabel);
-            Assert.IsNotNull(loaded);
+            Assert.That(loaded, Is.Not.Null);
             return loaded;
         }
 

--- a/Assets/SEETests/TestGraphProviderIO.cs
+++ b/Assets/SEETests/TestGraphProviderIO.cs
@@ -19,6 +19,7 @@ namespace SEE.GraphProviders
         {
             Assert.That(actual, Is.TypeOf(expected.GetType()));
             MultiGraphPipelineProvider graphPipelineLoaded = actual as MultiGraphPipelineProvider;
+            Assert.That(graphPipelineLoaded, Is.Not.Null);
             Assert.That(graphPipelineLoaded.Pipeline.Count, Is.EqualTo(expected.Pipeline.Count));
             for (int i = 0; i < expected.Pipeline.Count; i++)
             {
@@ -58,6 +59,7 @@ namespace SEE.GraphProviders
         {
             Assert.That(actual, Is.TypeOf(expected.GetType()));
             GitEvolutionGraphProvider gitLoaded = actual as GitEvolutionGraphProvider;
+            Assert.That(gitLoaded, Is.Not.Null);
             Assert.That(gitLoaded.Date, Is.EqualTo(expected.Date));
             AreEqual(expected.GitRepository.RepositoryPath, gitLoaded.GitRepository.RepositoryPath);
             AreEqualFilters(expected.GitRepository.VCSFilter, gitLoaded.GitRepository.VCSFilter);
@@ -285,6 +287,7 @@ namespace SEE.GraphProviders
         {
             Assert.That(actual, Is.TypeOf(expected.GetType()));
             SingleGraphPipelineProvider graphPipelineLoaded = actual as SingleGraphPipelineProvider;
+            Assert.That(graphPipelineLoaded, Is.Not.Null);
             Assert.That(graphPipelineLoaded.Pipeline.Count, Is.EqualTo(expected.Pipeline.Count));
             for (int i = 0; i < expected.Pipeline.Count; i++)
             {
@@ -317,6 +320,7 @@ namespace SEE.GraphProviders
         {
             Assert.That(actual, Is.TypeOf(expected.GetType()));
             GitBranchesGraphProvider gitBranchesLoaded = actual as GitBranchesGraphProvider;
+            Assert.That(gitBranchesLoaded, Is.Not.Null);
             Assert.That(gitBranchesLoaded.SimplifyGraph, Is.EqualTo(expected.SimplifyGraph));
         }
 

--- a/Assets/SEETests/TestGraphProviders.cs
+++ b/Assets/SEETests/TestGraphProviders.cs
@@ -33,9 +33,9 @@ namespace SEE.GraphProviders
             { Path = new DataPath(TestDataPath + "/JLGExample/CodeFacts.gxl.xz") };
 
             Graph loaded = await provider.ProvideAsync(new Graph(""), NewCity());
-            Assert.IsNotNull(loaded);
-            Assert.IsTrue(loaded.NodeCount > 0);
-            Assert.IsTrue(loaded.EdgeCount > 0);
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.NodeCount, Is.GreaterThan(0));
+            Assert.That(loaded.EdgeCount, Is.GreaterThan(0));
         }
 
         [Test]
@@ -65,21 +65,24 @@ namespace SEE.GraphProviders
                 }
 
                 Graph loaded = await graphPipeline.ProvideAsync(new Graph(""), NewCity());
-                Assert.IsNotNull(loaded);
-                Assert.IsTrue(loaded.NodeCount > 0);
-                Assert.IsTrue(loaded.EdgeCount > 0);
+                Assert.That(loaded, Is.Not.Null);
+                Assert.That(loaded.NodeCount, Is.GreaterThan(0));
+                Assert.That(loaded.EdgeCount, Is.GreaterThan(0));
 
-                Assert.IsTrue(loaded.TryGetNode("counter.CountToAThousand.countWithFibbonaci(I;)", out Node node));
+                Assert.That(loaded.TryGetNode("counter.CountToAThousand.countWithFibbonaci(I;)", out Node node),
+                            Is.True, "Node counter.CountToAThousand.countWithFibbonaci(I;) is missing.");
 
                 // Metric from JaCoCo report.
                 {
-                    Assert.IsTrue(node.TryGetInt(JaCoCo.BranchCovered, out int value));
-                    Assert.AreEqual(5, value);
+                    Assert.That(node.TryGetInt(JaCoCo.BranchCovered, out int value), Is.True,
+                                $"Node {node.ID} has no metric {JaCoCo.BranchCovered}.");
+                    Assert.That(value, Is.EqualTo(5));
                 }
                 // Metric from CSV import.
                 {
-                    Assert.IsTrue(node.TryGetInt(Metrics.Prefix + "Developers", out int value));
-                    Assert.AreEqual(3, value);
+                    Assert.That(node.TryGetInt(Metrics.Prefix + "Developers", out int value), Is.True,
+                                $"Node {node.ID} has no metric {Metrics.Prefix}Developers.");
+                    Assert.That(value, Is.EqualTo(3));
                 }
             }
             finally
@@ -111,24 +114,30 @@ namespace SEE.GraphProviders
 
                 Graph diffGraph = await mergeDiffProvider.ProvideAsync(graph, NewCity());
 
-                Assert.IsNotNull(diffGraph);
-                Assert.IsTrue(diffGraph.NodeCount > 0);
-                Assert.IsTrue(diffGraph.EdgeCount > 0);
+                Assert.That(diffGraph, Is.Not.Null);
+                Assert.That(diffGraph.NodeCount, Is.GreaterThan(0));
+                Assert.That(diffGraph.EdgeCount, Is.GreaterThan(0));
 
                 // Just a few checks. The underlying Diff-Merge algorithm is tested in more depth elsewhere.
                 {
-                    Assert.IsTrue(diffGraph.TryGetNode("p1.c1", out Node node));
-                    Assert.IsTrue(node.HasToggle(ChangeMarkers.IsChanged));
+                    Assert.That(diffGraph.TryGetNode("p1.c1", out Node node), Is.True,
+                                "Node p1.c1 is missing in the diff graph.");
+                    Assert.That(node.HasToggle(ChangeMarkers.IsChanged), Is.True,
+                                $"{node.ID} has no toggle {ChangeMarkers.IsChanged}.");
                 }
 
                 {
-                    Assert.IsTrue(diffGraph.TryGetNode("p1.c2", out Node node));
-                    Assert.IsTrue(node.HasToggle(ChangeMarkers.IsNew));
+                    Assert.That(diffGraph.TryGetNode("p1.c2", out Node node), Is.True,
+                                "Node p1.c2 is missing in the diff graph.");
+                    Assert.That(node.HasToggle(ChangeMarkers.IsNew), Is.True,
+                                $"{node.ID} has no toggle {ChangeMarkers.IsNew}.");
                 }
 
                 {
-                    Assert.IsTrue(diffGraph.TryGetEdge("Call#p1.c1#p1.c4", out Edge edge));
-                    Assert.IsTrue(edge.HasToggle(ChangeMarkers.IsDeleted));
+                    Assert.That(diffGraph.TryGetEdge("Call#p1.c1#p1.c4", out Edge edge), Is.True,
+                                "Edge Call#p1.c1#p1.c4 is missing in the diff graph.");
+                    Assert.That(edge.HasToggle(ChangeMarkers.IsDeleted), Is.True,
+                                $"{edge.ID} has no toggle {ChangeMarkers.IsDeleted}.");
                 }
             }
         }
@@ -164,7 +173,7 @@ namespace SEE.GraphProviders
                 pathsFromGraph.Add(node.ID);
             }
             pathsFromGraph.Sort();
-            Assert.AreEqual(expectedPaths, pathsFromGraph);
+            Assert.That(pathsFromGraph, Is.EqualTo(expectedPaths));
         }
 
         /// <summary>
@@ -195,20 +204,34 @@ namespace SEE.GraphProviders
 
         private static void AssertTokenMetricsExist(Node node)
         {
-            Assert.IsTrue(node.TryGetInt(Metrics.LOC, out int _));
-            Assert.IsTrue(node.TryGetInt(Metrics.McCabe, out int _));
-            Assert.IsTrue(node.TryGetInt(Halstead.DistinctOperators, out int _));
-            Assert.IsTrue(node.TryGetInt(Halstead.DistinctOperands, out int _));
-            Assert.IsTrue(node.TryGetInt(Halstead.TotalOperators, out int _));
-            Assert.IsTrue(node.TryGetInt(Halstead.TotalOperands, out int _));
-            Assert.IsTrue(node.TryGetInt(Halstead.ProgramVocabulary, out int _));
-            Assert.IsTrue(node.TryGetInt(Halstead.ProgramLength, out int _));
-            Assert.IsTrue(node.TryGetFloat(Halstead.EstimatedProgramLength, out float _));
-            Assert.IsTrue(node.TryGetFloat(Halstead.Volume, out float _));
-            Assert.IsTrue(node.TryGetFloat(Halstead.Difficulty, out float _));
-            Assert.IsTrue(node.TryGetFloat(Halstead.Effort, out float _));
-            Assert.IsTrue(node.TryGetFloat(Halstead.TimeRequiredToProgram, out float _));
-            Assert.IsTrue(node.TryGetFloat(Halstead.NumberOfDeliveredBugs, out float _));
+            Assert.That(node.TryGetInt(Metrics.LOC, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Metrics.LOC}.");
+            Assert.That(node.TryGetInt(Metrics.McCabe, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Metrics.McCabe}.");
+            Assert.That(node.TryGetInt(Halstead.DistinctOperators, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.DistinctOperators}.");
+            Assert.That(node.TryGetInt(Halstead.DistinctOperands, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.DistinctOperands}.");
+            Assert.That(node.TryGetInt(Halstead.TotalOperators, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.TotalOperators}.");
+            Assert.That(node.TryGetInt(Halstead.TotalOperands, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.TotalOperands}.");
+            Assert.That(node.TryGetInt(Halstead.ProgramVocabulary, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.ProgramVocabulary}.");
+            Assert.That(node.TryGetInt(Halstead.ProgramLength, out int _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.ProgramLength}.");
+            Assert.That(node.TryGetFloat(Halstead.EstimatedProgramLength, out float _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.EstimatedProgramLength}.");
+            Assert.That(node.TryGetFloat(Halstead.Volume, out float _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.Volume}.");
+            Assert.That(node.TryGetFloat(Halstead.Difficulty, out float _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.Difficulty}.");
+            Assert.That(node.TryGetFloat(Halstead.Effort, out float _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.Effort}.");
+            Assert.That(node.TryGetFloat(Halstead.TimeRequiredToProgram, out float _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.TimeRequiredToProgram}.");
+            Assert.That(node.TryGetFloat(Halstead.NumberOfDeliveredBugs, out float _), Is.True,
+                        $"Node {node.ID} has no metric {Halstead.NumberOfDeliveredBugs}.");
         }
 
         [Test]
@@ -230,11 +253,13 @@ namespace SEE.GraphProviders
         public async Task TestVCSMetricsAsync(string metric, int expected)
         {
             Graph graph = await GetVCSGraphAsync();
-            Assert.IsNotNull(graph);
-            Assert.IsTrue(graph.NodeCount > 0);
-            Assert.IsTrue(graph.TryGetNode("Assets/SEE/GraphProviders/VCSGraphProvider.cs", out Node node));
-            Assert.IsTrue(node.TryGetInt(metric, out int value));
-            Assert.AreEqual(expected, value);
+            Assert.That(graph, Is.Not.Null);
+            Assert.That(graph.NodeCount, Is.GreaterThan(0));
+            Assert.That(graph.TryGetNode("Assets/SEE/GraphProviders/VCSGraphProvider.cs", out Node node),
+                        Is.True, "Node Assets/SEE/GraphProviders/VCSGraphProvider.cs is missing.");
+            Assert.That(node.TryGetInt(metric, out int value), Is.True,
+                        $"Node {node.ID} has no metric {metric}.");
+            Assert.That(value, Is.EqualTo(expected));
         }
 
         /// <summary>

--- a/Assets/SEETests/TestIVersionControl.cs
+++ b/Assets/SEETests/TestIVersionControl.cs
@@ -29,8 +29,8 @@ namespace SEE.VCS
             p = Performance.Begin(nameof(TestIVersionControl));
             // We are using our own git repository of SEE as a guinea pig.
             vcs = new GitVersionControl(DataPath.ProjectFolder());
-            Assert.IsNotNull(vcs);
-            Assert.IsTrue(vcs is GitVersionControl);
+            Assert.That(vcs, Is.Not.Null, "The version control system must have been created.");
+            Assert.That(vcs, Is.InstanceOf<GitVersionControl>());
         }
 
         /// <summary>
@@ -83,10 +83,10 @@ namespace SEE.VCS
         private void AssertFile(string fileName, string revision, int expectedHash)
         {
             string content = vcs.Show(fileName, revision);
-            Assert.IsNotNull(content);
-            Assert.AreNotEqual(0, content.Length);
+            Assert.That(content, Is.Not.Null, "The file content must have been retrieved.");
+            Assert.That(content.Length, Is.Not.EqualTo(0));
             // Comparing the hash code is a convenient way to check whether we found the right file.
-            Assert.AreEqual(expectedHash, content.GetHashCode());
+            Assert.That(content.GetHashCode(), Is.EqualTo(expectedHash));
         }
 
         /// <summary>
@@ -119,31 +119,31 @@ namespace SEE.VCS
         [Test]
         public void TestRenamed()
         {
-            Assert.AreEqual(Change.Renamed,
-                            vcs.GetFileChange(gitVersionControl, slightlyOldCommit, newerCommit,
-                                                            out string oldFilename));
-            Assert.AreEqual(versionControlSystems, oldFilename);
+            Assert.That(vcs.GetFileChange(gitVersionControl, slightlyOldCommit, newerCommit,
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Renamed));
+            Assert.That(oldFilename, Is.EqualTo(versionControlSystems));
         }
 
         [Test]
         public void TestAdded()
         {
-            Assert.AreEqual(Change.Added,
-                            vcs.GetFileChange(gitVersionControl, oldCommit, newerCommit,
-                                                           out string oldFilename));
-            Assert.IsNull(oldFilename);
+            Assert.That(vcs.GetFileChange(gitVersionControl, oldCommit, newerCommit,
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Added));
+            Assert.That(oldFilename, Is.Null, "There is no former file name for this kind of change.");
         }
 
         [Test]
         public void TestDeleted()
         {
             const string filename = "Assets/Resources/Prefabs/Players/DesktopPlayer_BACKUP_565.prefab.meta";
-            Assert.AreEqual(Change.Deleted,
-                            vcs.GetFileChange(filename,
-                                                            "e63d92e0506c5c38b213a7a3420b4fca0187cfc2",
-                                                            "3de77399fcacf45a63094ebfb31ce708f03d1067",
-                                                            out string oldFilename));
-            Assert.AreEqual(filename, oldFilename);
+            Assert.That(vcs.GetFileChange(filename,
+                                          "e63d92e0506c5c38b213a7a3420b4fca0187cfc2",
+                                          "3de77399fcacf45a63094ebfb31ce708f03d1067",
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Deleted));
+            Assert.That(oldFilename, Is.EqualTo(filename));
         }
 
         [Test]
@@ -152,12 +152,12 @@ namespace SEE.VCS
             // Even though this file is an exact copy of "Assets/SEETests/DummyHereForTestVCS.cs",
             // it will be reported as Change.Added by the diff options we set. If we wanted to find
             // such copies, we would need to set option RenameDetectionMode.Copies.
-            Assert.AreEqual(Change.Added,
-                            vcs.GetFileChange(copyOfDummy,
-                                              "a38c505030ce716e45aa023a3f60524ea7d22ec4",
-                                              "888ded45ae3b2dbe52afaa1306cfda93bc69371a",
-                                              out string oldFilename));
-            Assert.IsNull(oldFilename);
+            Assert.That(vcs.GetFileChange(copyOfDummy,
+                                          "a38c505030ce716e45aa023a3f60524ea7d22ec4",
+                                          "888ded45ae3b2dbe52afaa1306cfda93bc69371a",
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Added));
+            Assert.That(oldFilename, Is.Null, "There is no former file name for this kind of change.");
         }
 
         [Test]
@@ -166,13 +166,13 @@ namespace SEE.VCS
             // Even though this file is an exact copy of "Assets/SEETests/DummyHereForTestVCS.cs",
             // it will be reported as Change.Added by the diff options we set. If we wanted to find
             // such copies, we would need to set option RenameDetectionMode.Copies.
-            Assert.AreEqual(Change.Modified,
-                            vcs.GetFileChange(copyOfDummy,
-                                              "888ded45ae3b2dbe52afaa1306cfda93bc69371a",
-                                              "1ddd84e32dc3c307d9e8a05773be0c1fb2bd8dae",
-                                              out string oldFilename));
-            Assert.IsNotNull(oldFilename);
-            Assert.AreEqual(copyOfDummy, oldFilename);
+            Assert.That(vcs.GetFileChange(copyOfDummy,
+                                          "888ded45ae3b2dbe52afaa1306cfda93bc69371a",
+                                          "1ddd84e32dc3c307d9e8a05773be0c1fb2bd8dae",
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Modified));
+            Assert.That(oldFilename, Is.Not.Null, "The former file name must be known for this kind of change.");
+            Assert.That(oldFilename, Is.EqualTo(copyOfDummy));
         }
 
         private const string test = "Assets/StreamingAssets/Test.txt";
@@ -182,68 +182,70 @@ namespace SEE.VCS
         [Test]
         public void TestTxtModified()
         {
-            Assert.AreEqual(Change.Modified,
-                vcs.GetFileChange(test,
-                                  "15e2f949406321b61a27e5df213961ef695fdd4f",
-                                  "30366de209448a9ad30aea04c7fac6946d2ec00f",
-                                  out string oldFilename));
-            Assert.IsNotNull(oldFilename);
-            Assert.AreEqual(test, oldFilename);
+            Assert.That(vcs.GetFileChange(test,
+                                          "15e2f949406321b61a27e5df213961ef695fdd4f",
+                                          "30366de209448a9ad30aea04c7fac6946d2ec00f",
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Modified));
+            Assert.That(oldFilename, Is.Not.Null, "The former file name must be known for this kind of change.");
+            Assert.That(oldFilename, Is.EqualTo(test));
         }
 
         [Test]
         public void TestTxtModifiedRenamed()
         {
-            Assert.AreEqual(Change.Renamed,
-                vcs.GetFileChange(renamed,
-                                  "15e2f949406321b61a27e5df213961ef695fdd4f",
-                                  "838e2887e6be66fa072c402b3d333f5c2b616389",
-                                  out string oldFilename));
-            Assert.IsNotNull(oldFilename);
-            Assert.AreEqual(test, oldFilename);
+            Assert.That(vcs.GetFileChange(renamed,
+                                          "15e2f949406321b61a27e5df213961ef695fdd4f",
+                                          "838e2887e6be66fa072c402b3d333f5c2b616389",
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Renamed));
+            Assert.That(oldFilename, Is.Not.Null, "The former file name must be known for this kind of change.");
+            Assert.That(oldFilename, Is.EqualTo(test));
         }
 
         [Test]
         public void TestTxtModifiedRenamedModified()
         {
-            Assert.AreEqual(Change.Renamed,
-                vcs.GetFileChange(renamed,
-                                  "15e2f949406321b61a27e5df213961ef695fdd4f",
-                                  "d46f356872cb73c2987b1d4525e87e96e8fbd4fc",
-                                  out string oldFilename));
-            Assert.IsNotNull(oldFilename);
-            Assert.AreEqual(test, oldFilename);
+            Assert.That(vcs.GetFileChange(renamed,
+                                          "15e2f949406321b61a27e5df213961ef695fdd4f",
+                                          "d46f356872cb73c2987b1d4525e87e96e8fbd4fc",
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Renamed));
+            Assert.That(oldFilename, Is.Not.Null, "The former file name must be known for this kind of change.");
+            Assert.That(oldFilename, Is.EqualTo(test));
         }
 
         [Test]
         public void TestTxtModifiedRenamedModified_Then_Modified_And_Renamed()
         {
-            Assert.AreEqual(Change.Renamed,
-                vcs.GetFileChange(modifiedAndRenamed,
-                                  "15e2f949406321b61a27e5df213961ef695fdd4f",
-                                  "3812c682de354e546342442f899af5d110976087",
-                                  out string oldFilename));
-            Assert.IsNotNull(oldFilename);
-            Assert.AreEqual(test, oldFilename);
+            Assert.That(vcs.GetFileChange(modifiedAndRenamed,
+                                          "15e2f949406321b61a27e5df213961ef695fdd4f",
+                                          "3812c682de354e546342442f899af5d110976087",
+                                          out string oldFilename),
+                        Is.EqualTo(Change.Renamed));
+            Assert.That(oldFilename, Is.Not.Null, "The former file name must be known for this kind of change.");
+            Assert.That(oldFilename, Is.EqualTo(test));
         }
 
         [Test]
         public void TestUnknownNewCommitID()
         {
-            Assert.Throws<UnknownCommitID>(() => vcs.GetFileChange(gitVersionControl, oldCommit, "DOESNOTEXIST", out string _));
+            Assert.That(() => vcs.GetFileChange(gitVersionControl, oldCommit, "DOESNOTEXIST", out string _),
+                        Throws.TypeOf<UnknownCommitID>());
         }
 
         [Test]
         public void TestUnknownOldCommitID()
         {
-            Assert.Throws<UnknownCommitID>(() => vcs.GetFileChange(gitVersionControl, "DOESNOTEXIST", newerCommit, out string _));
+            Assert.That(() => vcs.GetFileChange(gitVersionControl, "DOESNOTEXIST", newerCommit, out string _),
+                        Throws.TypeOf<UnknownCommitID>());
         }
 
         [Test]
         public void TestUnknown()
         {
-            Assert.AreEqual(Change.Unknown,
-                            vcs.GetFileChange("THIS_FILE_DOES_NOT_EXIST", slightlyOldCommit, newerCommit, out string _));
+            Assert.That(vcs.GetFileChange("THIS_FILE_DOES_NOT_EXIST", slightlyOldCommit, newerCommit, out string _),
+                        Is.EqualTo(Change.Unknown));
         }
     }
 }

--- a/Assets/SEETests/TestIncrementalReflexion.cs
+++ b/Assets/SEETests/TestIncrementalReflexion.cs
@@ -208,14 +208,24 @@ namespace SEE.Tools.Architecture
 
         private void AssertMapped(Node implNode, Node archNode)
         {
-            Assert.GreaterOrEqual(changes.OfType<EdgeEvent>().Count(x => x.Change == ChangeType.Addition && x.Affected == ReflexionSubgraphs.Mapping &&
-                                                                         x.Edge.Source.ID == implNode.ID && x.Edge.Target.ID == archNode.ID), 1);
+            Assert.That(changes.OfType<EdgeEvent>()
+                               .Count(x => x.Change == ChangeType.Addition
+                                           && x.Affected == ReflexionSubgraphs.Mapping
+                                           && x.Edge.Source.ID == implNode.ID
+                                           && x.Edge.Target.ID == archNode.ID),
+                        Is.GreaterThanOrEqualTo(1),
+                        $"There is no mapping edge from {implNode.ID} to {archNode.ID}.");
         }
 
         private void AssertUnmapped(Node implNode, Node archNode)
         {
-            Assert.GreaterOrEqual(changes.OfType<EdgeEvent>().Count(x => x.Change == ChangeType.Removal && x.Affected == ReflexionSubgraphs.Mapping &&
-                                                                         x.Edge.Source.ID == implNode.ID && x.Edge.Target.ID == archNode.ID), 1);
+            Assert.That(changes.OfType<EdgeEvent>()
+                               .Count(x => x.Change == ChangeType.Removal
+                                           && x.Affected == ReflexionSubgraphs.Mapping
+                                           && x.Edge.Source.ID == implNode.ID
+                                           && x.Edge.Target.ID == archNode.ID),
+                        Is.GreaterThanOrEqualTo(1),
+                        $"The mapping edge from {implNode.ID} to {archNode.ID} was not removed.");
         }
 
         /// <summary>
@@ -426,13 +436,17 @@ namespace SEE.Tools.Architecture
             Assert.That(IsAbsent(a1, a2, call));
             AssertEventCountEquals<EdgeChange>(1);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ReflexionSubgraphs.Mapping);
-            Assert.AreEqual(3, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(3));
 
             ResetEvents();
             graph.RemoveEdge(ea12);
             AssertEventCountEquals<EdgeChange>(0); // no matching propagated edge exists
-            Assert.AreEqual(1, changes.Count);
-            Assert.IsTrue(changes.OfType<EdgeEvent>().Single(x => x.Change == ChangeType.Removal && x.Affected == ReflexionSubgraphs.Architecture).Edge.Equals(ea12));
+            Assert.That(changes.Count, Is.EqualTo(1));
+            Assert.That(changes.OfType<EdgeEvent>()
+                               .Single(x => x.Change == ChangeType.Removal
+                                            && x.Affected == ReflexionSubgraphs.Architecture)
+                               .Edge,
+                        Is.EqualTo(ea12));
 
             // We will now check the "left side" scenario of the figure.
             // We will restore the "left side" state by using the incremental operations.
@@ -440,8 +454,11 @@ namespace SEE.Tools.Architecture
             graph.AddEdge(a1, a2, call);
             Assert.That(IsAbsent(a1, a2, call));
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.AreEqual(1, changes.OfType<EdgeEvent>().Count(x => x.Change == ChangeType.Addition && x.Affected == ReflexionSubgraphs.Architecture));
-            Assert.AreEqual(2, changes.Count);
+            Assert.That(changes.OfType<EdgeEvent>()
+                               .Count(x => x.Change == ChangeType.Addition
+                                           && x.Affected == ReflexionSubgraphs.Architecture),
+                        Is.EqualTo(1));
+            Assert.That(changes.Count, Is.EqualTo(2));
 
             ResetEvents();
             graph.AddEdge(i1, i2, call);
@@ -449,7 +466,7 @@ namespace SEE.Tools.Architecture
             Assert.That(IsAllowed(i1, i2, call));
             AssertEventCountEquals<EdgeChange>(2);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ignorePropagated: false);
-            Assert.AreEqual(4, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(4));
 
             // Now we can check what happens once we remove ea12 (an allowed edge should become divergent).
             ResetEvents();
@@ -457,7 +474,7 @@ namespace SEE.Tools.Architecture
             Assert.That(IsDivergent(i1, i2, call));
             AssertEventCountEquals<EdgeChange>(1);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture);
-            Assert.AreEqual(2, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(2));
 
             // And one last time, we add it back to check the `Add` operation.
             ResetEvents();
@@ -466,7 +483,7 @@ namespace SEE.Tools.Architecture
             Assert.That(IsAllowed(i1, i2, call));
             AssertEventCountEquals<EdgeChange>(2);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture);
-            Assert.AreEqual(3, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(3));
         }
 
         [Test]
@@ -476,9 +493,12 @@ namespace SEE.Tools.Architecture
             MapIncrementally();
             ResetEvents();
             graph.Unparent(i[7]);
-            Assert.AreEqual(changes
-                          .OfType<HierarchyEvent>()
-                          .Count(x => x.Child == i[7] && x.Parent == i[2] && x.Change == ChangeType.Removal && x.Affected == ReflexionSubgraphs.Implementation), 1);
+            Assert.That(changes.OfType<HierarchyEvent>()
+                               .Count(x => x.Child == i[7]
+                                           && x.Parent == i[2]
+                                           && x.Change == ChangeType.Removal
+                                           && x.Affected == ReflexionSubgraphs.Implementation),
+                        Is.EqualTo(1));
             Assert.That(IsUnpropagated(a[9], a[2], call));
             Assert.That(IsUnpropagated(a[9], a[9], call));
             Assert.That(IsUnpropagated(a[1], a[9], call));
@@ -487,14 +507,17 @@ namespace SEE.Tools.Architecture
             Assert.That(IsUnmapped(i[9], i[8], call));
             Assert.That(IsUnmapped(i[9], i[10], call));
             Assert.That(IsUnmapped(i[12], i[9], call));
-            Assert.AreEqual(changes.Count, 9);
+            Assert.That(changes.Count, Is.EqualTo(9));
 
             // Now, we add the relationship back.
             ResetEvents();
             graph.AddChildInImplementation(i[7], i[2]);
-            Assert.AreEqual(changes
-                          .OfType<HierarchyEvent>()
-                          .Count(x => x.Child == i[7] && x.Parent == i[2] && x.Change == ChangeType.Addition && x.Affected == ReflexionSubgraphs.Implementation), 1);
+            Assert.That(changes.OfType<HierarchyEvent>()
+                               .Count(x => x.Child == i[7]
+                                           && x.Parent == i[2]
+                                           && x.Change == ChangeType.Addition
+                                           && x.Affected == ReflexionSubgraphs.Implementation),
+                        Is.EqualTo(1));
             Assert.That(IsPropagated(a[9], a[2], call));
             Assert.That(IsPropagated(a[9], a[9], call));
             Assert.That(IsPropagated(a[1], a[9], call));
@@ -503,9 +526,9 @@ namespace SEE.Tools.Architecture
             Assert.That(IsDivergent(i[8], i[6], call));
             Assert.That(IsDivergent(i[12], i[9], call));
             Assert.That(IsImplicitlyAllowed(i[9], i[8], call));
-            Assert.AreEqual(changes.Count, 9);
-            Assert.Throws<NotAnOrphanException>(() => graph.AddChildInImplementation(i[7], i[2]));
-            Assert.Throws<CyclicHierarchyException>(() => graph.AddChildInImplementation(i[2], i[7]));
+            Assert.That(changes.Count, Is.EqualTo(9));
+            Assert.That(() => graph.AddChildInImplementation(i[7], i[2]), Throws.TypeOf<NotAnOrphanException>());
+            Assert.That(() => graph.AddChildInImplementation(i[2], i[7]), Throws.TypeOf<CyclicHierarchyException>());
         }
 
         [Test]
@@ -559,7 +582,7 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(3, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(4, ChangeType.Addition, ReflexionSubgraphs.Mapping);
             AssertEventCountEquals<EdgeEvent>(3, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
-            Assert.AreEqual(15, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(15));
 
             // Now we start testing what we actually want to check: Incremental changes to the arch hierarchy.
             ResetEvents();
@@ -568,14 +591,14 @@ namespace SEE.Tools.Architecture
             Assert.That(IsDivergent(i2, i3, call));
             Assert.That(IsDivergent(i2, i4, call));
             AssertEventCountEquals<HierarchyEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
-            Assert.AreEqual(4, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(4));
 
             // Quick diversion: Adding an edge from a'2 to a'3 should work, but then adding a'2 as a child to a2 should
             // result in a redundant specified edge.
             ResetEvents();
             graph.AddEdge(a_2, a_3, call);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture);
-            Assert.Throws<RedundantSpecifiedEdgeException>(() => graph.AddChildInArchitecture(a_2, a2));
+            Assert.That(() => graph.AddChildInArchitecture(a_2, a2), Throws.TypeOf<RedundantSpecifiedEdgeException>());
             ResetEvents();
             graph.RemoveFromArchitecture(a_2, a_3, call);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture);
@@ -586,13 +609,13 @@ namespace SEE.Tools.Architecture
             Assert.That(IsAllowed(i2, i3, call));
             Assert.That(IsAllowed(i2, i4, call));
             AssertEventCountEquals<HierarchyEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture);
-            Assert.AreEqual(4, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(4));
 
             // Now we test some additional error cases.
-            Assert.Throws<NotAnOrphanException>(() => graph.AddChildInArchitecture(a_2, a2));
-            Assert.Throws<CyclicHierarchyException>(() => graph.AddChildInArchitecture(a2, a_2));
-            Assert.Throws<NotInSubgraphException>(() => graph.AddChildInArchitecture(a2, i2));
-            Assert.Throws<RedundantSpecifiedEdgeException>(() => graph.AddEdge(a_2, a_3, call));
+            Assert.That(() => graph.AddChildInArchitecture(a_2, a2), Throws.TypeOf<NotAnOrphanException>());
+            Assert.That(() => graph.AddChildInArchitecture(a2, a_2), Throws.TypeOf<CyclicHierarchyException>());
+            Assert.That(() => graph.AddChildInArchitecture(a2, i2), Throws.TypeOf<NotInSubgraphException>());
+            Assert.That(() => graph.AddEdge(a_2, a_3, call), Throws.TypeOf<RedundantSpecifiedEdgeException>());
         }
 
         /// <summary>
@@ -835,7 +858,7 @@ namespace SEE.Tools.Architecture
             ResetEvents();
             graph.RemoveFromImplementation(ie[(14, 13)]);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Implementation);
-            Assert.AreEqual(1, changes.Count);
+            Assert.That(changes.Count, Is.EqualTo(1));
         }
 
         private static IEnumerable<IList<int>> BigIncrementalOrderings()

--- a/Assets/SEETests/TestIncrementalReflexion.cs
+++ b/Assets/SEETests/TestIncrementalReflexion.cs
@@ -257,9 +257,11 @@ namespace SEE.Tools.Architecture
             AssertMapped(i2, a1);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ignorePropagated: true);
-            Assert.That(IsPropagated(a1, a1, call));
+            Assert.That(IsPropagated(a1, a1, call), Is.True,
+                        $"Edge {a1.ID} -> {a1.ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsImplicitlyAllowed(i1, i2, call));
+            Assert.That(IsImplicitlyAllowed(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state ImplicitlyAllowed.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
             ResetEvents();
         }
@@ -293,9 +295,11 @@ namespace SEE.Tools.Architecture
             graph.AddMapsToEdge(i1, a1);
             AssertMapped(i1, a1);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ignorePropagated: false);
-            Assert.That(IsPropagated(a1, a1, call));
+            Assert.That(IsPropagated(a1, a1, call), Is.True,
+                        $"Edge {a1.ID} -> {a1.ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsImplicitlyAllowed(i1, i2, call));
+            Assert.That(IsImplicitlyAllowed(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state ImplicitlyAllowed.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
             ResetEvents();
         }
@@ -324,9 +328,11 @@ namespace SEE.Tools.Architecture
             graph.AddMapsToEdge(i2, a2);
             AssertMapped(i2, a2);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ignorePropagated: false);
-            Assert.That(IsPropagated(a1, a2, call));
+            Assert.That(IsPropagated(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsDivergent(i1, i2, call));
+            Assert.That(IsDivergent(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state Divergent.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
             ResetEvents();
 
@@ -334,19 +340,23 @@ namespace SEE.Tools.Architecture
             graph.RemoveFromMapping(i1);
             AssertUnmapped(i1, a1);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Removal, ignorePropagated: false);
-            Assert.That(IsUnpropagated(a1, a2, call));
+            Assert.That(IsUnpropagated(a1, a2, call), Is.True,
+                        $"Propagated edge {a1.ID} -> {a2.ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ignorePropagated: false);
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsUnmapped(i1, i2, call));
+            Assert.That(IsUnmapped(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state Unmapped.");
             ResetEvents();
 
             // i1 -> a2
             graph.AddMapsToEdge(i1, a2);
             AssertMapped(i1, a2);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ignorePropagated: false);
-            Assert.That(IsPropagated(a2, a2, call));
+            Assert.That(IsPropagated(a2, a2, call), Is.True,
+                        $"Edge {a2.ID} -> {a2.ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsImplicitlyAllowed(i1, i2, call));
+            Assert.That(IsImplicitlyAllowed(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state ImplicitlyAllowed.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
         }
 
@@ -374,7 +384,8 @@ namespace SEE.Tools.Architecture
             Edge ea12 = AddToGraph(call, a_1, a_2);
             ResetEvents();
             SetupReflexion();
-            Assert.That(IsAbsent(a_1, a_2, call));
+            Assert.That(IsAbsent(a_1, a_2, call), Is.True,
+                        $"Edge {a_1.ID} -> {a_2.ID} must have changed to state Absent.");
 
             ResetEvents();
             graph.AddMapsToEdge(i_1, a1);
@@ -386,27 +397,37 @@ namespace SEE.Tools.Architecture
 
             ResetEvents();
             graph.AddEdge(i1, i2, call);
-            Assert.That(IsConvergent(a_1, a_2, call));
-            Assert.That(IsPropagated(a1, a2, call));
-            Assert.That(IsAllowed(i1, i2, call));
+            Assert.That(IsConvergent(a_1, a_2, call), Is.True,
+                        $"Edge {a_1.ID} -> {a_2.ID} must have changed to state Convergent.");
+            Assert.That(IsPropagated(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must have been propagated to the architecture.");
+            Assert.That(IsAllowed(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state Allowed.");
 
             ResetEvents();
             graph.AddEdge(i_1, i_2, call);
-            Assert.That(IsNotContained(a_1, a_2, call));
-            Assert.That(IsNotContained(a1, a2, call));
-            Assert.That(IsAllowed(i_1, i_2, call));
+            Assert.That(IsNotContained(a_1, a_2, call), Is.True,
+                        $"Edge {a_1.ID} -> {a_2.ID} must not have changed its state.");
+            Assert.That(IsNotContained(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must not have changed its state.");
+            Assert.That(IsAllowed(i_1, i_2, call), Is.True,
+                        $"Edge {i_1.ID} -> {i_2.ID} must have changed to state Allowed.");
 
             // Test deletion
 
             ResetEvents();
             graph.RemoveFromImplementation(i_1, i_2, call);
-            Assert.That(IsNotContained(a_1, a_2, call));
-            Assert.That(IsNotContained(a1, a2, call));
+            Assert.That(IsNotContained(a_1, a_2, call), Is.True,
+                        $"Edge {a_1.ID} -> {a_2.ID} must not have changed its state.");
+            Assert.That(IsNotContained(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must not have changed its state.");
 
             ResetEvents();
             graph.RemoveFromImplementation(i1, i2, call);
-            Assert.That(IsAbsent(a_1, a_2, call));
-            Assert.That(IsUnpropagated(a1, a2, call));
+            Assert.That(IsAbsent(a_1, a_2, call), Is.True,
+                        $"Edge {a_1.ID} -> {a_2.ID} must have changed to state Absent.");
+            Assert.That(IsUnpropagated(a1, a2, call), Is.True,
+                        $"Propagated edge {a1.ID} -> {a2.ID} must have been removed from the architecture.");
         }
 
         [Test]
@@ -433,7 +454,8 @@ namespace SEE.Tools.Architecture
             SetupReflexion();
             graph.AddMapsToEdge(i1, a_1);
             graph.AddMapsToEdge(i2, a_2);
-            Assert.That(IsAbsent(a1, a2, call));
+            Assert.That(IsAbsent(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must have changed to state Absent.");
             AssertEventCountEquals<EdgeChange>(1);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ReflexionSubgraphs.Mapping);
             Assert.That(changes.Count, Is.EqualTo(3));
@@ -452,7 +474,8 @@ namespace SEE.Tools.Architecture
             // We will restore the "left side" state by using the incremental operations.
             ResetEvents();
             graph.AddEdge(a1, a2, call);
-            Assert.That(IsAbsent(a1, a2, call));
+            Assert.That(IsAbsent(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must have changed to state Absent.");
             AssertEventCountEquals<EdgeChange>(1);
             Assert.That(changes.OfType<EdgeEvent>()
                                .Count(x => x.Change == ChangeType.Addition
@@ -462,8 +485,10 @@ namespace SEE.Tools.Architecture
 
             ResetEvents();
             graph.AddEdge(i1, i2, call);
-            Assert.That(IsConvergent(a1, a2, call));
-            Assert.That(IsAllowed(i1, i2, call));
+            Assert.That(IsConvergent(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must have changed to state Convergent.");
+            Assert.That(IsAllowed(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state Allowed.");
             AssertEventCountEquals<EdgeChange>(2);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ignorePropagated: false);
             Assert.That(changes.Count, Is.EqualTo(4));
@@ -471,7 +496,8 @@ namespace SEE.Tools.Architecture
             // Now we can check what happens once we remove ea12 (an allowed edge should become divergent).
             ResetEvents();
             graph.RemoveFromArchitecture(a1, a2, call);
-            Assert.That(IsDivergent(i1, i2, call));
+            Assert.That(IsDivergent(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state Divergent.");
             AssertEventCountEquals<EdgeChange>(1);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture);
             Assert.That(changes.Count, Is.EqualTo(2));
@@ -479,8 +505,10 @@ namespace SEE.Tools.Architecture
             // And one last time, we add it back to check the `Add` operation.
             ResetEvents();
             graph.AddEdge(a1, a2, call);
-            Assert.That(IsConvergent(a1, a2, call));
-            Assert.That(IsAllowed(i1, i2, call));
+            Assert.That(IsConvergent(a1, a2, call), Is.True,
+                        $"Edge {a1.ID} -> {a2.ID} must have changed to state Convergent.");
+            Assert.That(IsAllowed(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state Allowed.");
             AssertEventCountEquals<EdgeChange>(2);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture);
             Assert.That(changes.Count, Is.EqualTo(3));
@@ -499,14 +527,22 @@ namespace SEE.Tools.Architecture
                                            && x.Change == ChangeType.Removal
                                            && x.Affected == ReflexionSubgraphs.Implementation),
                         Is.EqualTo(1));
-            Assert.That(IsUnpropagated(a[9], a[2], call));
-            Assert.That(IsUnpropagated(a[9], a[9], call));
-            Assert.That(IsUnpropagated(a[1], a[9], call));
-            Assert.That(IsUnpropagated(a[9], a[3], call));
-            Assert.That(IsUnmapped(i[8], i[6], call));
-            Assert.That(IsUnmapped(i[9], i[8], call));
-            Assert.That(IsUnmapped(i[9], i[10], call));
-            Assert.That(IsUnmapped(i[12], i[9], call));
+            Assert.That(IsUnpropagated(a[9], a[2], call), Is.True,
+                        $"Propagated edge {a[9].ID} -> {a[2].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[9], a[9], call), Is.True,
+                        $"Propagated edge {a[9].ID} -> {a[9].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[1], a[9], call), Is.True,
+                        $"Propagated edge {a[1].ID} -> {a[9].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[9], a[3], call), Is.True,
+                        $"Propagated edge {a[9].ID} -> {a[3].ID} must have been removed from the architecture.");
+            Assert.That(IsUnmapped(i[8], i[6], call), Is.True,
+                        $"Edge {i[8].ID} -> {i[6].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[9], i[8], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[8].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[9], i[10], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[10].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[12], i[9], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[9].ID} must have changed to state Unmapped.");
             Assert.That(changes.Count, Is.EqualTo(9));
 
             // Now, we add the relationship back.
@@ -518,14 +554,22 @@ namespace SEE.Tools.Architecture
                                            && x.Change == ChangeType.Addition
                                            && x.Affected == ReflexionSubgraphs.Implementation),
                         Is.EqualTo(1));
-            Assert.That(IsPropagated(a[9], a[2], call));
-            Assert.That(IsPropagated(a[9], a[9], call));
-            Assert.That(IsPropagated(a[1], a[9], call));
-            Assert.That(IsPropagated(a[9], a[3], call));
-            Assert.That(IsDivergent(i[9], i[10], call));
-            Assert.That(IsDivergent(i[8], i[6], call));
-            Assert.That(IsDivergent(i[12], i[9], call));
-            Assert.That(IsImplicitlyAllowed(i[9], i[8], call));
+            Assert.That(IsPropagated(a[9], a[2], call), Is.True,
+                        $"Edge {a[9].ID} -> {a[2].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[9], a[9], call), Is.True,
+                        $"Edge {a[9].ID} -> {a[9].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[1], a[9], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[9].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[9], a[3], call), Is.True,
+                        $"Edge {a[9].ID} -> {a[3].ID} must have been propagated to the architecture.");
+            Assert.That(IsDivergent(i[9], i[10], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[10].ID} must have changed to state Divergent.");
+            Assert.That(IsDivergent(i[8], i[6], call), Is.True,
+                        $"Edge {i[8].ID} -> {i[6].ID} must have changed to state Divergent.");
+            Assert.That(IsDivergent(i[12], i[9], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[9].ID} must have changed to state Divergent.");
+            Assert.That(IsImplicitlyAllowed(i[9], i[8], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[8].ID} must have changed to state ImplicitlyAllowed.");
             Assert.That(changes.Count, Is.EqualTo(9));
             Assert.That(() => graph.AddChildInImplementation(i[7], i[2]), Throws.TypeOf<NotAnOrphanException>());
             Assert.That(() => graph.AddChildInImplementation(i[2], i[7]), Throws.TypeOf<CyclicHierarchyException>());
@@ -573,11 +617,16 @@ namespace SEE.Tools.Architecture
 
             ResetEvents();
             graph.RunAnalysis();
-            Assert.That(IsAbsent(a2, a1, call));
-            Assert.That(IsConvergent(a2, a3, call));
-            Assert.That(IsDivergent(i1, i2, call));
-            Assert.That(IsAllowed(i2, i3, call));
-            Assert.That(IsAllowed(i2, i4, call));
+            Assert.That(IsAbsent(a2, a1, call), Is.True,
+                        $"Edge {a2.ID} -> {a1.ID} must have changed to state Absent.");
+            Assert.That(IsConvergent(a2, a3, call), Is.True,
+                        $"Edge {a2.ID} -> {a3.ID} must have changed to state Convergent.");
+            Assert.That(IsDivergent(i1, i2, call), Is.True,
+                        $"Edge {i1.ID} -> {i2.ID} must have changed to state Divergent.");
+            Assert.That(IsAllowed(i2, i3, call), Is.True,
+                        $"Edge {i2.ID} -> {i3.ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i2, i4, call), Is.True,
+                        $"Edge {i2.ID} -> {i4.ID} must have changed to state Allowed.");
             AssertEventCountEquals<EdgeChange>(5);
             AssertEventCountEquals<EdgeEvent>(3, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(4, ChangeType.Addition, ReflexionSubgraphs.Mapping);
@@ -587,9 +636,12 @@ namespace SEE.Tools.Architecture
             // Now we start testing what we actually want to check: Incremental changes to the arch hierarchy.
             ResetEvents();
             graph.Unparent(a_2);
-            Assert.That(IsAbsent(a2, a3, call));
-            Assert.That(IsDivergent(i2, i3, call));
-            Assert.That(IsDivergent(i2, i4, call));
+            Assert.That(IsAbsent(a2, a3, call), Is.True,
+                        $"Edge {a2.ID} -> {a3.ID} must have changed to state Absent.");
+            Assert.That(IsDivergent(i2, i3, call), Is.True,
+                        $"Edge {i2.ID} -> {i3.ID} must have changed to state Divergent.");
+            Assert.That(IsDivergent(i2, i4, call), Is.True,
+                        $"Edge {i2.ID} -> {i4.ID} must have changed to state Divergent.");
             AssertEventCountEquals<HierarchyEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             Assert.That(changes.Count, Is.EqualTo(4));
 
@@ -605,9 +657,12 @@ namespace SEE.Tools.Architecture
 
             ResetEvents();
             graph.AddChildInArchitecture(a_2, a2);
-            Assert.That(IsConvergent(a2, a3, call));
-            Assert.That(IsAllowed(i2, i3, call));
-            Assert.That(IsAllowed(i2, i4, call));
+            Assert.That(IsConvergent(a2, a3, call), Is.True,
+                        $"Edge {a2.ID} -> {a3.ID} must have changed to state Convergent.");
+            Assert.That(IsAllowed(i2, i3, call), Is.True,
+                        $"Edge {i2.ID} -> {i3.ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i2, i4, call), Is.True,
+                        $"Edge {i2.ID} -> {i4.ID} must have changed to state Allowed.");
             AssertEventCountEquals<HierarchyEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture);
             Assert.That(changes.Count, Is.EqualTo(4));
 
@@ -640,22 +695,28 @@ namespace SEE.Tools.Architecture
             ResetEvents();
             graph.AddMapsToEdge(i[3], a[3]);
             AssertEventCountEquals<EdgeChange>(3);
-            Assert.That(IsConvergent(a[3], a[7], call));
-            Assert.That(IsAllowed(i[5], i[17], call));
-            Assert.That(IsAllowed(i[4], i[16], call));
+            Assert.That(IsConvergent(a[3], a[7], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[7].ID} must have changed to state Convergent.");
+            Assert.That(IsAllowed(i[5], i[17], call), Is.True,
+                        $"Edge {i[5].ID} -> {i[17].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[4], i[16], call), Is.True,
+                        $"Edge {i[4].ID} -> {i[16].ID} must have changed to state Allowed.");
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsPropagated(a[3], a[6], call));
+            Assert.That(IsPropagated(a[3], a[6], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[6].ID} must have been propagated to the architecture.");
             AssertMapped(i[3], a[3]);
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
 
             ResetEvents();
             graph.AddMapsToEdge(i[15], a[5]);
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsAllowed(i[3], i[15], call));
+            Assert.That(IsAllowed(i[3], i[15], call), Is.True,
+                        $"Edge {i[3].ID} -> {i[15].ID} must have changed to state Allowed.");
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsPropagated(a[3], a[5], call));
+            Assert.That(IsPropagated(a[3], a[5], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[5].ID} must have been propagated to the architecture.");
             AssertMapped(i[15], a[5]);
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
 
@@ -664,16 +725,25 @@ namespace SEE.Tools.Architecture
             AssertMapped(i[1], a[1]);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsPropagated(a[1], a[3], call));
-            Assert.That(IsPropagated(a[1], a[1], call));
+            Assert.That(IsPropagated(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[1], a[1], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[1].ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeChange>(7);
-            Assert.That(IsAllowed(i[8], i[6], call));
-            Assert.That(IsAllowed(i[9], i[8], call));
-            Assert.That(IsAllowed(i[9], i[10], call));
-            Assert.That(IsAllowed(i[12], i[9], call));
-            Assert.That(IsAllowed(i[12], i[10], call));
-            Assert.That(IsConvergent(a[1], a[3], call));
-            Assert.That(IsConvergent(a[8], a[8], call));
+            Assert.That(IsAllowed(i[8], i[6], call), Is.True,
+                        $"Edge {i[8].ID} -> {i[6].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[9], i[8], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[8].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[9], i[10], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[10].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[12], i[9], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[9].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[12], i[10], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[10].ID} must have changed to state Allowed.");
+            Assert.That(IsConvergent(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have changed to state Convergent.");
+            Assert.That(IsConvergent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Convergent.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
 
             ResetEvents();
@@ -681,9 +751,11 @@ namespace SEE.Tools.Architecture
             AssertMapped(i[14], a[4]);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsPropagated(a[4], a[1], call));
+            Assert.That(IsPropagated(a[4], a[1], call), Is.True,
+                        $"Edge {a[4].ID} -> {a[1].ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsDivergent(i[14], i[13], call));
+            Assert.That(IsDivergent(i[14], i[13], call), Is.True,
+                        $"Edge {i[14].ID} -> {i[13].ID} must have changed to state Divergent.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
 
             ResetEvents();
@@ -691,32 +763,49 @@ namespace SEE.Tools.Architecture
             AssertMapped(i[2], a[9]);
             AssertEventCountEquals<EdgeEvent>(3, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsPropagated(a[9], a[3], call));
-            Assert.That(IsPropagated(a[1], a[9], call));
-            Assert.That(IsPropagated(a[9], a[9], call));
+            Assert.That(IsPropagated(a[9], a[3], call), Is.True,
+                        $"Edge {a[9].ID} -> {a[3].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[1], a[9], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[9].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[9], a[9], call), Is.True,
+                        $"Edge {a[9].ID} -> {a[9].ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Removal, ignorePropagated: false);
-            Assert.That(IsUnpropagated(a[1], a[3], call));
-            Assert.That(IsUnpropagated(a[1], a[1], call));
+            Assert.That(IsUnpropagated(a[1], a[3], call), Is.True,
+                        $"Propagated edge {a[1].ID} -> {a[3].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[1], a[1], call), Is.True,
+                        $"Propagated edge {a[1].ID} -> {a[1].ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeChange>(7);
-            Assert.That(IsDivergent(i[8], i[6], call));
-            Assert.That(IsDivergent(i[12], i[9], call));
-            Assert.That(IsDivergent(i[12], i[10], call));
-            Assert.That(IsImplicitlyAllowed(i[9], i[8], call));
-            Assert.That(IsImplicitlyAllowed(i[9], i[10], call));
-            Assert.That(IsAbsent(a[1], a[3], call));
-            Assert.That(IsAbsent(a[8], a[8], call));
+            Assert.That(IsDivergent(i[8], i[6], call), Is.True,
+                        $"Edge {i[8].ID} -> {i[6].ID} must have changed to state Divergent.");
+            Assert.That(IsDivergent(i[12], i[9], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[9].ID} must have changed to state Divergent.");
+            Assert.That(IsDivergent(i[12], i[10], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[10].ID} must have changed to state Divergent.");
+            Assert.That(IsImplicitlyAllowed(i[9], i[8], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[8].ID} must have changed to state ImplicitlyAllowed.");
+            Assert.That(IsImplicitlyAllowed(i[9], i[10], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[10].ID} must have changed to state ImplicitlyAllowed.");
+            Assert.That(IsAbsent(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Absent.");
 
             ResetEvents();
             graph.AddMapsToEdge(i[10], a[2]);
             AssertMapped(i[10], a[2]);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsPropagated(a[1], a[2], call));
-            Assert.That(IsPropagated(a[9], a[2], call));
+            Assert.That(IsPropagated(a[1], a[2], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[2].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[9], a[2], call), Is.True,
+                        $"Edge {a[9].ID} -> {a[2].ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeChange>(3);
-            Assert.That(IsAllowed(i[12], i[10], call));
-            Assert.That(IsDivergent(i[9], i[10], call));
-            Assert.That(IsConvergent(a[8], a[8], call));
+            Assert.That(IsAllowed(i[12], i[10], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[10].ID} must have changed to state Allowed.");
+            Assert.That(IsDivergent(i[9], i[10], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[10].ID} must have changed to state Divergent.");
+            Assert.That(IsConvergent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Convergent.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ignorePropagated: false);
         }
 
@@ -726,10 +815,14 @@ namespace SEE.Tools.Architecture
             //--------------------
             // initial state
             //--------------------
-            Assert.That(IsAbsent(a[3], a[7], call));
-            Assert.That(IsAbsent(a[1], a[3], call));
-            Assert.That(IsAbsent(a[8], a[8], call));
-            Assert.That(IsAbsent(a[2], a[4], call));
+            Assert.That(IsAbsent(a[3], a[7], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[7].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[2], a[4], call), Is.True,
+                        $"Edge {a[2].ID} -> {a[4].ID} must have changed to state Absent.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ReflexionSubgraphs.Mapping);
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
@@ -747,30 +840,45 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsUnpropagated(a[1], a[2], call));
-            Assert.That(IsUnpropagated(a[9], a[2], call));
+            Assert.That(IsUnpropagated(a[1], a[2], call), Is.True,
+                        $"Propagated edge {a[1].ID} -> {a[2].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[9], a[2], call), Is.True,
+                        $"Propagated edge {a[9].ID} -> {a[2].ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeChange>(3);
-            Assert.That(IsAbsent(a[8], a[8], call));
+            Assert.That(IsAbsent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Absent.");
 
             ResetEvents();
             graph.RemoveFromMapping(i[2]);
             AssertUnmapped(i[2], a[9]);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsPropagated(a[1], a[3], call));
-            Assert.That(IsPropagated(a[1], a[1], call));
+            Assert.That(IsPropagated(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[1], a[1], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[1].ID} must have been propagated to the architecture.");
             AssertEventCountEquals<EdgeEvent>(3, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
-            Assert.That(IsUnpropagated(a[9], a[3], call));
-            Assert.That(IsUnpropagated(a[1], a[9], call));
-            Assert.That(IsUnpropagated(a[9], a[9], call));
+            Assert.That(IsUnpropagated(a[9], a[3], call), Is.True,
+                        $"Propagated edge {a[9].ID} -> {a[3].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[1], a[9], call), Is.True,
+                        $"Propagated edge {a[1].ID} -> {a[9].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[9], a[9], call), Is.True,
+                        $"Propagated edge {a[9].ID} -> {a[9].ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeChange>(7);
-            Assert.That(IsConvergent(a[1], a[3], call));
-            Assert.That(IsConvergent(a[8], a[8], call));
-            Assert.That(IsAllowed(i[8], i[6], call));
-            Assert.That(IsAllowed(i[9], i[8], call));
-            Assert.That(IsAllowed(i[9], i[10], call));
-            Assert.That(IsAllowed(i[12], i[9], call));
-            Assert.That(IsAllowed(i[12], i[10], call));
+            Assert.That(IsConvergent(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have changed to state Convergent.");
+            Assert.That(IsConvergent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Convergent.");
+            Assert.That(IsAllowed(i[8], i[6], call), Is.True,
+                        $"Edge {i[8].ID} -> {i[6].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[9], i[8], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[8].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[9], i[10], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[10].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[12], i[9], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[9].ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(i[12], i[10], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[10].ID} must have changed to state Allowed.");
 
             ResetEvents();
             graph.RemoveFromMapping(i[14]);
@@ -778,9 +886,11 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsUnpropagated(a[4], a[1], call));
+            Assert.That(IsUnpropagated(a[4], a[1], call), Is.True,
+                        $"Propagated edge {a[4].ID} -> {a[1].ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsUnmapped(i[14], i[13], call));
+            Assert.That(IsUnmapped(i[14], i[13], call), Is.True,
+                        $"Edge {i[14].ID} -> {i[13].ID} must have changed to state Unmapped.");
 
             ResetEvents();
             graph.RemoveFromMapping(i[1]);
@@ -788,16 +898,25 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(2, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Mapping, ignorePropagated: true);
-            Assert.That(IsUnpropagated(a[1], a[3], call));
-            Assert.That(IsUnpropagated(a[1], a[1], call));
+            Assert.That(IsUnpropagated(a[1], a[3], call), Is.True,
+                        $"Propagated edge {a[1].ID} -> {a[3].ID} must have been removed from the architecture.");
+            Assert.That(IsUnpropagated(a[1], a[1], call), Is.True,
+                        $"Propagated edge {a[1].ID} -> {a[1].ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeChange>(7);
-            Assert.That(IsAbsent(a[8], a[8], call));
-            Assert.That(IsAbsent(a[1], a[3], call));
-            Assert.That(IsUnmapped(i[8], i[6], call));
-            Assert.That(IsUnmapped(i[9], i[8], call));
-            Assert.That(IsUnmapped(i[9], i[10], call));
-            Assert.That(IsUnmapped(i[12], i[9], call));
-            Assert.That(IsUnmapped(i[12], i[10], call));
+            Assert.That(IsAbsent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have changed to state Absent.");
+            Assert.That(IsUnmapped(i[8], i[6], call), Is.True,
+                        $"Edge {i[8].ID} -> {i[6].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[9], i[8], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[8].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[9], i[10], call), Is.True,
+                        $"Edge {i[9].ID} -> {i[10].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[12], i[9], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[9].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[12], i[10], call), Is.True,
+                        $"Edge {i[12].ID} -> {i[10].ID} must have changed to state Unmapped.");
 
             ResetEvents();
             graph.RemoveFromMapping(i[15]);
@@ -805,9 +924,11 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ignorePropagated: true);
-            Assert.That(IsUnpropagated(a[3], a[5], call));
+            Assert.That(IsUnpropagated(a[3], a[5], call), Is.True,
+                        $"Propagated edge {a[3].ID} -> {a[5].ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeChange>(1);
-            Assert.That(IsUnmapped(i[3], i[15], call));
+            Assert.That(IsUnmapped(i[3], i[15], call), Is.True,
+                        $"Edge {i[3].ID} -> {i[15].ID} must have changed to state Unmapped.");
 
             ResetEvents();
             graph.RemoveFromMapping(i[3]);
@@ -815,11 +936,15 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Removal, ignorePropagated: true);
-            Assert.That(IsUnpropagated(a[3], a[6], call));
+            Assert.That(IsUnpropagated(a[3], a[6], call), Is.True,
+                        $"Propagated edge {a[3].ID} -> {a[6].ID} must have been removed from the architecture.");
             AssertEventCountEquals<EdgeChange>(3);
-            Assert.That(IsAbsent(a[3], a[7], call));
-            Assert.That(IsUnmapped(i[4], i[16], call));
-            Assert.That(IsUnmapped(i[5], i[17], call));
+            Assert.That(IsAbsent(a[3], a[7], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[7].ID} must have changed to state Absent.");
+            Assert.That(IsUnmapped(i[4], i[16], call), Is.True,
+                        $"Edge {i[4].ID} -> {i[16].ID} must have changed to state Unmapped.");
+            Assert.That(IsUnmapped(i[5], i[17], call), Is.True,
+                        $"Edge {i[5].ID} -> {i[17].ID} must have changed to state Unmapped.");
 
             ResetEvents();
             graph.RemoveFromMapping(i[16]);
@@ -845,10 +970,14 @@ namespace SEE.Tools.Architecture
             // initial state
             //--------------------
 
-            Assert.That(IsAbsent(a[3], a[7], call));
-            Assert.That(IsAbsent(a[1], a[3], call));
-            Assert.That(IsAbsent(a[8], a[8], call));
-            Assert.That(IsAbsent(a[2], a[4], call));
+            Assert.That(IsAbsent(a[3], a[7], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[7].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(a[2], a[4], call), Is.True,
+                        $"Edge {a[2].ID} -> {a[4].ID} must have changed to state Absent.");
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ReflexionSubgraphs.Mapping);
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
             AssertEventCountEquals<EdgeEvent>(0, ChangeType.Removal, ReflexionSubgraphs.Architecture, ignorePropagated: false);
@@ -914,17 +1043,28 @@ namespace SEE.Tools.Architecture
             AssertMapped(i[14], a[4]);
             // Only in Figure 8: AssertMapped(i[2], a[9]);
             AssertMapped(i[10], a[2]);
-            Assert.That(IsConvergent(a[3], a[7], call));
-            Assert.That(IsConvergent(a[1], a[3], call));
-            Assert.That(IsConvergent(a[8], a[8], call));
-            Assert.That(IsAbsent(a[2], a[4], call));
-            Assert.That(IsDivergent(i[14], i[13], call));
-            Assert.That(IsPropagated(a[3], a[5], call));
-            Assert.That(IsPropagated(a[3], a[6], call));
-            Assert.That(IsPropagated(a[1], a[3], call));
-            Assert.That(IsPropagated(a[1], a[1], call));
-            Assert.That(IsPropagated(a[1], a[2], call));
-            Assert.That(IsPropagated(a[4], a[1], call));
+            Assert.That(IsConvergent(a[3], a[7], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[7].ID} must have changed to state Convergent.");
+            Assert.That(IsConvergent(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have changed to state Convergent.");
+            Assert.That(IsConvergent(a[8], a[8], call), Is.True,
+                        $"Edge {a[8].ID} -> {a[8].ID} must have changed to state Convergent.");
+            Assert.That(IsAbsent(a[2], a[4], call), Is.True,
+                        $"Edge {a[2].ID} -> {a[4].ID} must have changed to state Absent.");
+            Assert.That(IsDivergent(i[14], i[13], call), Is.True,
+                        $"Edge {i[14].ID} -> {i[13].ID} must have changed to state Divergent.");
+            Assert.That(IsPropagated(a[3], a[5], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[5].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[3], a[6], call), Is.True,
+                        $"Edge {a[3].ID} -> {a[6].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[1], a[3], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[3].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[1], a[1], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[1].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[1], a[2], call), Is.True,
+                        $"Edge {a[1].ID} -> {a[2].ID} must have been propagated to the architecture.");
+            Assert.That(IsPropagated(a[4], a[1], call), Is.True,
+                        $"Edge {a[4].ID} -> {a[1].ID} must have been propagated to the architecture.");
             AssertEventCountEquals<HierarchyEvent>(4, ChangeType.Addition, ReflexionSubgraphs.Architecture);
             AssertEventCountEquals<HierarchyEvent>(12, ChangeType.Addition, ReflexionSubgraphs.Implementation);
             AssertEventCountEquals<NodeEvent>(9, ChangeType.Addition, ReflexionSubgraphs.Architecture);

--- a/Assets/SEETests/TestJacocoImporter.cs
+++ b/Assets/SEETests/TestJacocoImporter.cs
@@ -4,7 +4,6 @@ using SEE.DataModel.DG.IO;
 using SEE.Utils.Paths;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace SEE.DataModel.DG

--- a/Assets/SEETests/TestJacocoImporter.cs
+++ b/Assets/SEETests/TestJacocoImporter.cs
@@ -149,6 +149,8 @@ namespace SEE.DataModel.DG
         public void AddMetricToMethodNode()
         {
             Node nodeToTest = graph.GetNode("counter.CountConsonants.countConsonants(java.lang.String;)");
+            Assert.That(nodeToTest, Is.Not.Null,
+                        "There is no node counter.CountConsonants.countConsonants(java.lang.String;).");
 
             Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(0));
             Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(39));

--- a/Assets/SEETests/TestJacocoImporter.cs
+++ b/Assets/SEETests/TestJacocoImporter.cs
@@ -95,23 +95,23 @@ namespace SEE.DataModel.DG
             Node nodeToTest = graph.GetNode("counter.CountConsonants");
             Assert.That(nodeToTest, Is.Not.Null, "There is no node counter.CountConsonants.");
 
-            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(7f));
-            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(130f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(7));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(130));
 
-            Assert.That(nodeToTest.GetInt(JaCoCo.BranchMissed), Is.EqualTo(0.0f));
-            Assert.That(nodeToTest.GetInt(JaCoCo.BranchCovered), Is.EqualTo(6f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchCovered), Is.EqualTo(6));
 
-            Assert.That(nodeToTest.GetInt(JaCoCo.LineMissed), Is.EqualTo(3f));
-            Assert.That(nodeToTest.GetInt(JaCoCo.LineCovered), Is.EqualTo(11f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineMissed), Is.EqualTo(3));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineCovered), Is.EqualTo(11));
 
-            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityMissed), Is.EqualTo(2f));
-            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityCovered), Is.EqualTo(5f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityMissed), Is.EqualTo(2));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityCovered), Is.EqualTo(5));
 
-            Assert.That(nodeToTest.GetInt(JaCoCo.MethodMissed), Is.EqualTo(2f));
-            Assert.That(nodeToTest.GetInt(JaCoCo.MethodCovered), Is.EqualTo(2f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodMissed), Is.EqualTo(2));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodCovered), Is.EqualTo(2));
 
-            Assert.That(nodeToTest.GetInt(JaCoCo.ClassMissed), Is.EqualTo(0f));
-            Assert.That(nodeToTest.GetInt(JaCoCo.ClassCovered), Is.EqualTo(1f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassCovered), Is.EqualTo(1));
         }
 
         /// <summary>

--- a/Assets/SEETests/TestJacocoImporter.cs
+++ b/Assets/SEETests/TestJacocoImporter.cs
@@ -65,25 +65,25 @@ namespace SEE.DataModel.DG
         public void AddMetricToRootNode()
         {
             Node nodeToTest = graph.GetRoots()[0];
-            Assert.IsNotNull(nodeToTest);
+            Assert.That(nodeToTest, Is.Not.Null, "The graph must have a root node.");
 
-            Assert.AreEqual(1313, nodeToTest.GetInt(JaCoCo.InstructionMissed));
-            Assert.AreEqual(441, nodeToTest.GetInt(JaCoCo.InstructionCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(1313));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(441));
 
-            Assert.AreEqual(101, nodeToTest.GetInt(JaCoCo.BranchMissed));
-            Assert.AreEqual(27, nodeToTest.GetInt(JaCoCo.BranchCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchMissed), Is.EqualTo(101));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchCovered), Is.EqualTo(27));
 
-            Assert.AreEqual(330, nodeToTest.GetInt(JaCoCo.LineMissed));
-            Assert.AreEqual(83, nodeToTest.GetInt(JaCoCo.LineCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineMissed), Is.EqualTo(330));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineCovered), Is.EqualTo(83));
 
-            Assert.AreEqual(107, nodeToTest.GetInt(JaCoCo.ComplexityMissed));
-            Assert.AreEqual(20, nodeToTest.GetInt(JaCoCo.ComplexityCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityMissed), Is.EqualTo(107));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityCovered), Is.EqualTo(20));
 
-            Assert.AreEqual(55, nodeToTest.GetInt(JaCoCo.MethodMissed));
-            Assert.AreEqual(8, nodeToTest.GetInt(JaCoCo.MethodCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodMissed), Is.EqualTo(55));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodCovered), Is.EqualTo(8));
 
-            Assert.AreEqual(6, nodeToTest.GetInt(JaCoCo.ClassMissed));
-            Assert.AreEqual(4, nodeToTest.GetInt(JaCoCo.ClassCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassMissed), Is.EqualTo(6));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassCovered), Is.EqualTo(4));
         }
 
         /// <summary>
@@ -93,25 +93,25 @@ namespace SEE.DataModel.DG
         public void AddMetricToClassNode()
         {
             Node nodeToTest = graph.GetNode("counter.CountConsonants");
-            Assert.IsNotNull(nodeToTest);
+            Assert.That(nodeToTest, Is.Not.Null, "There is no node counter.CountConsonants.");
 
-            Assert.AreEqual(7f, nodeToTest.GetInt(JaCoCo.InstructionMissed));
-            Assert.AreEqual(130f, nodeToTest.GetInt(JaCoCo.InstructionCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(7f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(130f));
 
-            Assert.AreEqual(0.0f, nodeToTest.GetInt(JaCoCo.BranchMissed));
-            Assert.AreEqual(6f, nodeToTest.GetInt(JaCoCo.BranchCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchMissed), Is.EqualTo(0.0f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchCovered), Is.EqualTo(6f));
 
-            Assert.AreEqual(3f, nodeToTest.GetInt(JaCoCo.LineMissed));
-            Assert.AreEqual(11f, nodeToTest.GetInt(JaCoCo.LineCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineMissed), Is.EqualTo(3f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineCovered), Is.EqualTo(11f));
 
-            Assert.AreEqual(2f, nodeToTest.GetInt(JaCoCo.ComplexityMissed));
-            Assert.AreEqual(5f, nodeToTest.GetInt(JaCoCo.ComplexityCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityMissed), Is.EqualTo(2f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityCovered), Is.EqualTo(5f));
 
-            Assert.AreEqual(2f, nodeToTest.GetInt(JaCoCo.MethodMissed));
-            Assert.AreEqual(2f, nodeToTest.GetInt(JaCoCo.MethodCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodMissed), Is.EqualTo(2f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodCovered), Is.EqualTo(2f));
 
-            Assert.AreEqual(0f, nodeToTest.GetInt(JaCoCo.ClassMissed));
-            Assert.AreEqual(1f, nodeToTest.GetInt(JaCoCo.ClassCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassMissed), Is.EqualTo(0f));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassCovered), Is.EqualTo(1f));
         }
 
         /// <summary>
@@ -121,25 +121,25 @@ namespace SEE.DataModel.DG
         public void AddMetricToPackageNode()
         {
             Node nodeToTest = graph.GetNode("counter");
-            Assert.IsNotNull(nodeToTest);
+            Assert.That(nodeToTest, Is.Not.Null, "There is no node counter.");
 
-            Assert.AreEqual(31, nodeToTest.GetInt(JaCoCo.InstructionMissed));
-            Assert.AreEqual(313, nodeToTest.GetInt(JaCoCo.InstructionCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(31));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(313));
 
-            Assert.AreEqual(1, nodeToTest.GetInt(JaCoCo.BranchMissed));
-            Assert.AreEqual(17, nodeToTest.GetInt(JaCoCo.BranchCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchMissed), Is.EqualTo(1));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchCovered), Is.EqualTo(17));
 
-            Assert.AreEqual(13, nodeToTest.GetInt(JaCoCo.LineMissed));
-            Assert.AreEqual(45, nodeToTest.GetInt(JaCoCo.LineCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineMissed), Is.EqualTo(13));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineCovered), Is.EqualTo(45));
 
-            Assert.AreEqual(9, nodeToTest.GetInt(JaCoCo.ComplexityMissed));
-            Assert.AreEqual(14, nodeToTest.GetInt(JaCoCo.ComplexityCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityMissed), Is.EqualTo(9));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityCovered), Is.EqualTo(14));
 
-            Assert.AreEqual(8, nodeToTest.GetInt(JaCoCo.MethodMissed));
-            Assert.AreEqual(6, nodeToTest.GetInt(JaCoCo.MethodCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodMissed), Is.EqualTo(8));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodCovered), Is.EqualTo(6));
 
-            Assert.AreEqual(0, nodeToTest.GetInt(JaCoCo.ClassMissed));
-            Assert.AreEqual(3, nodeToTest.GetInt(JaCoCo.ClassCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassCovered), Is.EqualTo(3));
         }
 
         /// <summary>
@@ -150,20 +150,20 @@ namespace SEE.DataModel.DG
         {
             Node nodeToTest = graph.GetNode("counter.CountConsonants.countConsonants(java.lang.String;)");
 
-            Assert.AreEqual(0, nodeToTest.GetInt(JaCoCo.InstructionMissed));
-            Assert.AreEqual(39, nodeToTest.GetInt(JaCoCo.InstructionCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(39));
 
-            Assert.AreEqual(0, nodeToTest.GetInt(JaCoCo.BranchMissed));
-            Assert.AreEqual(6, nodeToTest.GetInt(JaCoCo.BranchCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchCovered), Is.EqualTo(6));
 
-            Assert.AreEqual(0, nodeToTest.GetInt(JaCoCo.LineMissed));
-            Assert.AreEqual(8, nodeToTest.GetInt(JaCoCo.LineCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineCovered), Is.EqualTo(8));
 
-            Assert.AreEqual(0, nodeToTest.GetInt(JaCoCo.ComplexityMissed));
-            Assert.AreEqual(4, nodeToTest.GetInt(JaCoCo.ComplexityCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityCovered), Is.EqualTo(4));
 
-            Assert.AreEqual(0, nodeToTest.GetInt(JaCoCo.MethodMissed));
-            Assert.AreEqual(1, nodeToTest.GetInt(JaCoCo.MethodCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodCovered), Is.EqualTo(1));
         }
 
         /// <summary>
@@ -200,23 +200,23 @@ namespace SEE.DataModel.DG
 
             await JaCoCoImporter.LoadAsync(graph, path);
 
-            Assert.AreEqual(30, nodeToTest.GetInt(JaCoCo.InstructionMissed));
-            Assert.AreEqual(10, nodeToTest.GetInt(JaCoCo.InstructionCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionMissed), Is.EqualTo(30));
+            Assert.That(nodeToTest.GetInt(JaCoCo.InstructionCovered), Is.EqualTo(10));
 
-            Assert.AreEqual(3, nodeToTest.GetInt(JaCoCo.BranchMissed));
-            Assert.AreEqual(1, nodeToTest.GetInt(JaCoCo.BranchCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchMissed), Is.EqualTo(3));
+            Assert.That(nodeToTest.GetInt(JaCoCo.BranchCovered), Is.EqualTo(1));
 
-            Assert.AreEqual(10, nodeToTest.GetInt(JaCoCo.LineMissed));
-            Assert.AreEqual(3, nodeToTest.GetInt(JaCoCo.LineCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineMissed), Is.EqualTo(10));
+            Assert.That(nodeToTest.GetInt(JaCoCo.LineCovered), Is.EqualTo(3));
 
-            Assert.AreEqual(6, nodeToTest.GetInt(JaCoCo.ComplexityMissed));
-            Assert.AreEqual(1, nodeToTest.GetInt(JaCoCo.ComplexityCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityMissed), Is.EqualTo(6));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ComplexityCovered), Is.EqualTo(1));
 
-            Assert.AreEqual(4, nodeToTest.GetInt(JaCoCo.MethodMissed));
-            Assert.AreEqual(1, nodeToTest.GetInt(JaCoCo.MethodCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodMissed), Is.EqualTo(4));
+            Assert.That(nodeToTest.GetInt(JaCoCo.MethodCovered), Is.EqualTo(1));
 
-            Assert.AreEqual(0, nodeToTest.GetInt(JaCoCo.ClassMissed));
-            Assert.AreEqual(1, nodeToTest.GetInt(JaCoCo.ClassCovered));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassMissed), Is.EqualTo(0));
+            Assert.That(nodeToTest.GetInt(JaCoCo.ClassCovered), Is.EqualTo(1));
         }
     }
 }

--- a/Assets/SEETests/TestKeyMap.cs
+++ b/Assets/SEETests/TestKeyMap.cs
@@ -21,7 +21,8 @@ namespace SEE.Controls.KeyActions
             KeyActionDescriptor expected = new("Help", "Provides help", KeyActionCategory.General, KeyCode.H);
             map.Bind(KeyAction.Help, expected);
 
-            Assert.IsTrue(map.TryGetValue(KeyAction.Help, out KeyActionDescriptor actual));
+            Assert.That(map.TryGetValue(KeyAction.Help, out KeyActionDescriptor actual), Is.True,
+                        $"There is no binding for {KeyAction.Help}.");
             AreEqual(expected, actual);
         }
 
@@ -34,10 +35,10 @@ namespace SEE.Controls.KeyActions
         /// only these are stored in a binding file.</remarks>
         private void AreEqual(KeyActionDescriptor expected, KeyActionDescriptor actual)
         {
-            Assert.AreEqual(expected.Name, actual.Name);
-            Assert.AreEqual(expected.KeyCode, actual.KeyCode);
-            Assert.AreEqual(expected.Category, actual.Category);
-            Assert.AreEqual(expected.Description, actual.Description);
+            Assert.That(actual.Name, Is.EqualTo(expected.Name), "Name");
+            Assert.That(actual.KeyCode, Is.EqualTo(expected.KeyCode), "KeyCode");
+            Assert.That(actual.Category, Is.EqualTo(expected.Category), "Category");
+            Assert.That(actual.Description, Is.EqualTo(expected.Description), "Description");
         }
 
         /// <summary>
@@ -142,24 +143,27 @@ namespace SEE.Controls.KeyActions
 
                 // menu is only in loadedMap, must not be lost or changed
                 {
-                    Assert.IsTrue(loadedMap.TryGetKeyActionDescriptorByName(menu, out KeyActionDescriptor actual));
+                    Assert.That(loadedMap.TryGetKeyActionDescriptorByName(menu, out KeyActionDescriptor actual),
+                                Is.True, $"There is no binding named {menu}.");
                     AreEqual(menuDescriptor, actual);
                 }
 
                 {
                     // helpAction is in both bindings, but its key code was changed
-                    Assert.IsTrue(loadedMap.TryGetKeyActionDescriptorByName(help, out KeyActionDescriptor actual));
+                    Assert.That(loadedMap.TryGetKeyActionDescriptorByName(help, out KeyActionDescriptor actual),
+                                Is.True, $"There is no binding named {help}.");
                     // help was saved with KeyCode.H
-                    Assert.AreEqual(KeyCode.H, actual.KeyCode);
+                    Assert.That(actual.KeyCode, Is.EqualTo(KeyCode.H));
                 }
 
                 {
                     // snapAction was saved, but is not contained in loadedMap
                     // => must not be added to loadedMap (unknown bindings are ignored)
-                    Assert.IsFalse(loadedMap.TryGetKeyActionDescriptorByName(snap, out KeyActionDescriptor _));
+                    Assert.That(loadedMap.TryGetKeyActionDescriptorByName(snap, out KeyActionDescriptor _),
+                                Is.False, $"There must be no binding named {snap}.");
                 }
 
-                Assert.AreEqual(2, loadedMap.Count);
+                Assert.That(loadedMap.Count, Is.EqualTo(2));
             }
             finally
             {
@@ -185,7 +189,7 @@ namespace SEE.Controls.KeyActions
                 KeyMap loadedMap = new();
                 loadedMap.Bind(KeyAction.Help, NewDescriptor("Help", KeyCode.X));
                 loadedMap.Bind(KeyAction.ToggleMenu, NewDescriptor("Toggle", KeyCode.Y));
-                Assert.Throws(Is.TypeOf<Exception>(), () => loadedMap.Load(filename));
+                Assert.That(() => loadedMap.Load(filename), Throws.TypeOf<Exception>());
             }
             finally
             {
@@ -202,8 +206,8 @@ namespace SEE.Controls.KeyActions
         {
             KeyMap map = new();
             map.Bind(KeyAction.Help, NewDescriptor("Help", KeyCode.X));
-            Assert.Throws(Is.TypeOf<ArgumentException>(),
-                          () => map.Bind(KeyAction.ToggleMenu, NewDescriptor("Toggle", KeyCode.X)));
+            Assert.That(() => map.Bind(KeyAction.ToggleMenu, NewDescriptor("Toggle", KeyCode.X)),
+                        Throws.TypeOf<ArgumentException>());
         }
 
         /// <summary>
@@ -226,7 +230,8 @@ namespace SEE.Controls.KeyActions
         {
             foreach (var binding in subset)
             {
-                Assert.IsTrue(superset.TryGetValue(binding.Key, out KeyActionDescriptor supersetBinding));
+                Assert.That(superset.TryGetValue(binding.Key, out KeyActionDescriptor supersetBinding), Is.True,
+                            $"The superset has no binding for {binding.Key}.");
                 AreEqual(binding.Value, supersetBinding);
             }
         }

--- a/Assets/SEETests/TestLCAFinder.cs
+++ b/Assets/SEETests/TestLCAFinder.cs
@@ -87,7 +87,7 @@ namespace SEE.Layout
             LNode root = NewVertex();
             LCAFinder<LNode> lca = new LCAFinder<LNode>(root);
 
-            Assert.AreEqual(root, lca.LCA(root, root));
+            Assert.That(lca.LCA(root, root), Is.EqualTo(root));
         }
 
         [Test]
@@ -104,11 +104,11 @@ namespace SEE.Layout
 
             LCAFinder<LNode> lca = new LCAFinder<LNode>(root);
 
-            Assert.AreEqual(root, lca.LCA(a, b));
-            Assert.AreEqual(root, lca.LCA(root, b));
-            Assert.AreEqual(root, lca.LCA(b, root));
-            Assert.AreEqual(root, lca.LCA(a, root));
-            Assert.AreEqual(root, lca.LCA(root, a));
+            Assert.That(lca.LCA(a, b), Is.EqualTo(root));
+            Assert.That(lca.LCA(root, b), Is.EqualTo(root));
+            Assert.That(lca.LCA(b, root), Is.EqualTo(root));
+            Assert.That(lca.LCA(a, root), Is.EqualTo(root));
+            Assert.That(lca.LCA(root, a), Is.EqualTo(root));
         }
 
         [Test]
@@ -127,16 +127,16 @@ namespace SEE.Layout
 
             LCAFinder<LNode> lca = new LCAFinder<LNode>(root);
 
-            Assert.AreEqual(root, lca.LCA(root, root));
+            Assert.That(lca.LCA(root, root), Is.EqualTo(root));
 
-            Assert.AreEqual(a, lca.LCA(a, b));
-            Assert.AreEqual(a, lca.LCA(b, a));
+            Assert.That(lca.LCA(a, b), Is.EqualTo(a));
+            Assert.That(lca.LCA(b, a), Is.EqualTo(a));
 
-            Assert.AreEqual(root, lca.LCA(a, root));
-            Assert.AreEqual(root, lca.LCA(root, a));
+            Assert.That(lca.LCA(a, root), Is.EqualTo(root));
+            Assert.That(lca.LCA(root, a), Is.EqualTo(root));
 
-            Assert.AreEqual(root, lca.LCA(b, root));
-            Assert.AreEqual(root, lca.LCA(root, b));
+            Assert.That(lca.LCA(b, root), Is.EqualTo(root));
+            Assert.That(lca.LCA(root, b), Is.EqualTo(root));
         }
 
         [Test]
@@ -178,12 +178,12 @@ namespace SEE.Layout
 
             LCAFinder<LNode> lca = new LCAFinder<LNode>(root);
 
-            Assert.AreEqual(a, lca.LCA(a1, a2));
-            Assert.AreEqual(root, lca.LCA(a2, b1));
-            Assert.AreEqual(root, lca.LCA(b1, c12));
-            Assert.AreEqual(c1, lca.LCA(c11, c12));
-            Assert.AreEqual(c, lca.LCA(c2, c12));
-            Assert.AreEqual(c, lca.LCA(c1, c));
+            Assert.That(lca.LCA(a1, a2), Is.EqualTo(a));
+            Assert.That(lca.LCA(a2, b1), Is.EqualTo(root));
+            Assert.That(lca.LCA(b1, c12), Is.EqualTo(root));
+            Assert.That(lca.LCA(c11, c12), Is.EqualTo(c1));
+            Assert.That(lca.LCA(c2, c12), Is.EqualTo(c));
+            Assert.That(lca.LCA(c1, c), Is.EqualTo(c));
         }
 
         [Test]
@@ -228,16 +228,16 @@ namespace SEE.Layout
 
             LCAFinder<LNode> lca = new LCAFinder<LNode>(roots);
 
-            Assert.AreEqual(a, lca.LCA(a1, a2));
-            Assert.AreEqual(r1, lca.LCA(a2, b1));
+            Assert.That(lca.LCA(a1, a2), Is.EqualTo(a));
+            Assert.That(lca.LCA(a2, b1), Is.EqualTo(r1));
 
-            Assert.AreEqual(c1, lca.LCA(c11, c12));
-            Assert.AreEqual(c, lca.LCA(c2, c12));
-            Assert.AreEqual(c, lca.LCA(c1, c));
-            Assert.AreEqual(r2, lca.LCA(r2, c12));
+            Assert.That(lca.LCA(c11, c12), Is.EqualTo(c1));
+            Assert.That(lca.LCA(c2, c12), Is.EqualTo(c));
+            Assert.That(lca.LCA(c1, c), Is.EqualTo(c));
+            Assert.That(lca.LCA(r2, c12), Is.EqualTo(r2));
 
-            Assert.AreEqual(null, lca.LCA(b1, c12));
-            Assert.AreEqual(null, lca.LCA(r1, r2));
+            Assert.That(lca.LCA(b1, c12), Is.Null);
+            Assert.That(lca.LCA(r1, r2), Is.Null);
         }
     }
 }

--- a/Assets/SEETests/TestLayoutIO.cs
+++ b/Assets/SEETests/TestLayoutIO.cs
@@ -46,9 +46,10 @@ namespace SEE.Layout
                 Dictionary<ILayoutNode, NodeTransform> readLayout = new LoadedNodeLayout(filename).Create(gameObjects, Vector3.zero, Vector2.one);
                 //Dump(readLayout, 10);
 
-                Assert.AreEqual(savedLayout.Count, readLayout.Count); // no gameObject added or removed
-                                                                      // Now layoutMap and readLayout should be the same except for
-                                                                      // scale.y and, thus, position.y (none of those are stored in GVL).
+                Assert.That(readLayout.Count, Is.EqualTo(savedLayout.Count),
+                            "No game object may be added or removed.");
+                // Now layoutMap and readLayout should be the same except for
+                // scale.y and, thus, position.y (none of those are stored in GVL).
                 LayoutsAreEqual(readLayout, layoutMap, yIsStored);
             }
             finally
@@ -90,9 +91,10 @@ namespace SEE.Layout
                 Dictionary<ILayoutNode, NodeTransform> readLayout = new LoadedNodeLayout(filename).Create(layoutNodes, Vector3.zero, Vector2.one);
                 //Dump(readLayout, 10, "Read layout");
 
-                Assert.AreEqual(layoutMap.Count, readLayout.Count); // no gameObject added or removed
-                                                                    // Now layoutMap and readLayout should be the same including
-                                                                    // scale.y and, thus, position.y (all of those are stored in GVL).
+                Assert.That(readLayout.Count, Is.EqualTo(layoutMap.Count),
+                            "No game object may be added or removed.");
+                // Now layoutMap and readLayout should be the same including
+                // scale.y and, thus, position.y (all of those are stored in GVL).
                 LayoutsAreEqual(readLayout, layoutMap, yIsStored);
             }
             finally
@@ -176,7 +178,7 @@ namespace SEE.Layout
                     Assert.That(readTransform.CenterPosition.y, Is.EqualTo(savedTransform.CenterPosition.y).Within(floatTolerance));
                 }
                 Assert.That(readTransform.Z, Is.EqualTo(savedTransform.Z).Within(floatTolerance));
-                Assert.AreEqual(savedTransform.Rotation, readTransform.Rotation);
+                Assert.That(readTransform.Rotation, Is.EqualTo(savedTransform.Rotation));
             }
         }
 
@@ -321,7 +323,7 @@ namespace SEE.Layout
                 // Read the saved layout.
                 LoadedNodeLayout loadedNodeLayout = new(filename);
                 Dictionary<ILayoutNode, NodeTransform> readLayout = loadedNodeLayout.Create(new List<ILayoutNode>(), Vector3.zero, Vector2.one);
-                Assert.AreEqual(0, readLayout.Count);
+                Assert.That(readLayout, Is.Empty);
             }
             finally
             {

--- a/Assets/SEETests/TestLocalGitRepository.cs
+++ b/Assets/SEETests/TestLocalGitRepository.cs
@@ -33,11 +33,18 @@ namespace SEE.VCS
         ///
         /// Then a git commit is made
         /// </summary>
-        /// <param name="path">The path of the file</param>
+        /// <param name="repo">The repository to commit the file to</param>
+        /// <param name="gitDirPath">The path of the working directory of <paramref name="repo"/></param>
+        /// <param name="path">The path of the file, relative to <paramref name="gitDirPath"/>. It must not
+        /// be rooted: <see cref="Path.Combine(string, string)"/> would then silently drop
+        /// <paramref name="gitDirPath"/>, and the Git index accepts relative paths only.</param>
         /// <param name="text">The text the file should have</param>
         /// <param name="author">The author of the commit</param>
         private static void WriteFile(Repository repo, string gitDirPath, string path, string text, Signature author)
         {
+            Assert.That(Path.IsPathRooted(path), Is.False,
+                        $"{nameof(path)} must be relative to the repository.");
+
             if (Path.GetDirectoryName(path) != "")
             {
                 Directory.CreateDirectory(Path.Combine(gitDirPath, Path.GetDirectoryName(path)));

--- a/Assets/SEETests/TestLocalGitRepository.cs
+++ b/Assets/SEETests/TestLocalGitRepository.cs
@@ -50,7 +50,20 @@ namespace SEE.VCS
             repo.Commit("One Commit", author, author);
         }
 
+        /// <summary>
+        /// The name of the file that <see cref="SetUp"/> commits to the original
+        /// repository and that is expected in both repositories afterwards.
+        /// </summary>
+        private const string firstFile = "firstFile.cs";
+
+        /// <summary>
+        /// Path of the original repository, created by <see cref="SetUp"/>.
+        /// </summary>
         private static string originalRepoPath;
+
+        /// <summary>
+        /// Path of the clone of the original repository, created by <see cref="SetUp"/>.
+        /// </summary>
         private static string cloneRepoPath;
 
         [SetUp]
@@ -65,7 +78,7 @@ namespace SEE.VCS
             // Create and populate original repository.
             Debug.Log($"Creating original repository at {Repository.Init(originalRepoPath)}\n");
             using Repository original = new(originalRepoPath);
-            WriteFile(original, originalRepoPath, "firstFile.cs", "This is a test", developer);
+            WriteFile(original, originalRepoPath, firstFile, "This is a test", developer);
 
             // Clone original repository into clone repository.
             Debug.Log($"Cloning original repository into {Repository.Clone(originalRepoPath, cloneRepoPath)}\n");
@@ -81,8 +94,8 @@ namespace SEE.VCS
             Assert.That(Repository.IsValid(cloneRepoPath), Is.True,
                         $"{cloneRepoPath} is not a valid Git repository.");
 
-            Assert.That(new FileInfo(Path.Combine(originalRepoPath, "firstFile.cs")), Does.Exist);
-            Assert.That(new FileInfo(Path.Combine(cloneRepoPath, "firstFile.cs")), Does.Exist);
+            Assert.That(new FileInfo(Path.Combine(originalRepoPath, firstFile)), Does.Exist);
+            Assert.That(new FileInfo(Path.Combine(cloneRepoPath, firstFile)), Does.Exist);
         }
 
         [Test]

--- a/Assets/SEETests/TestLocalGitRepository.cs
+++ b/Assets/SEETests/TestLocalGitRepository.cs
@@ -33,13 +33,13 @@ namespace SEE.VCS
         ///
         /// Then a git commit is made
         /// </summary>
-        /// <param name="repo">The repository to commit the file to</param>
-        /// <param name="gitDirPath">The path of the working directory of <paramref name="repo"/></param>
+        /// <param name="repo">The repository to commit the file to.</param>
+        /// <param name="gitDirPath">The path of the working directory of <paramref name="repo"/>.</param>
         /// <param name="path">The path of the file, relative to <paramref name="gitDirPath"/>. It must not
-        /// be rooted: <see cref="Path.Combine(string, string)"/> would then silently drop
+        /// be rooted: <see cref="Path.Combine(string, string)"/> would then silently drop.
         /// <paramref name="gitDirPath"/>, and the Git index accepts relative paths only.</param>
-        /// <param name="text">The text the file should have</param>
-        /// <param name="author">The author of the commit</param>
+        /// <param name="text">The text the file should have.</param>
+        /// <param name="author">The author of the commit.</param>
         private static void WriteFile(Repository repo, string gitDirPath, string path, string text, Signature author)
         {
             Assert.That(Path.IsPathRooted(path), Is.False,

--- a/Assets/SEETests/TestLocalGitRepository.cs
+++ b/Assets/SEETests/TestLocalGitRepository.cs
@@ -74,13 +74,15 @@ namespace SEE.VCS
         [Test]
         public void TestSuccessfulCloning()
         {
-            Assert.IsTrue(Directory.Exists(originalRepoPath));
-            Assert.IsTrue(Directory.Exists(cloneRepoPath));
-            Assert.IsTrue(Repository.IsValid(originalRepoPath));
-            Assert.IsTrue(Repository.IsValid(cloneRepoPath));
+            Assert.That(new DirectoryInfo(originalRepoPath), Does.Exist);
+            Assert.That(new DirectoryInfo(cloneRepoPath), Does.Exist);
+            Assert.That(Repository.IsValid(originalRepoPath), Is.True,
+                        $"{originalRepoPath} is not a valid Git repository.");
+            Assert.That(Repository.IsValid(cloneRepoPath), Is.True,
+                        $"{cloneRepoPath} is not a valid Git repository.");
 
-            Assert.IsTrue(File.Exists(Path.Combine(originalRepoPath, "firstFile.cs")));
-            Assert.IsTrue(File.Exists(Path.Combine(cloneRepoPath, "firstFile.cs")));
+            Assert.That(new FileInfo(Path.Combine(originalRepoPath, "firstFile.cs")), Does.Exist);
+            Assert.That(new FileInfo(Path.Combine(cloneRepoPath, "firstFile.cs")), Does.Exist);
         }
 
         [Test]
@@ -89,10 +91,10 @@ namespace SEE.VCS
             using Repository original = new(originalRepoPath);
             GitRepository clone = new(new DataPath(cloneRepoPath), null);
 
-            Assert.IsFalse(clone.FetchRemotes());
+            Assert.That(clone.FetchRemotes(), Is.False, "There is nothing to be fetched yet.");
 
             WriteFile(original, originalRepoPath, "secondFile.cs", "This is a second test", developer);
-            Assert.IsTrue(clone.FetchRemotes());
+            Assert.That(clone.FetchRemotes(), Is.True, "The new commit must have been fetched.");
 
             // Create a new branch in original repository.
             // Define the name of the new branch.
@@ -101,18 +103,20 @@ namespace SEE.VCS
             // Create the new branch pointing to the current commit
             Branch newBranch = original.CreateBranch(newBranchName);
             Debug.Log($"Branch '{newBranch.FriendlyName}' created successfully.\n");
-            Assert.IsTrue(clone.FetchRemotes());
+            Assert.That(clone.FetchRemotes(), Is.True, "The new branch must have been fetched.");
 
             // Commit another file to the new branch.
             Commands.Checkout(original, newBranchName);
             WriteFile(original, originalRepoPath, "thirdFile.cs", "This is a third test", developer);
-            Assert.IsTrue(clone.FetchRemotes());
+            Assert.That(clone.FetchRemotes(), Is.True,
+                        "The commit on the new branch must have been fetched.");
 
             // Delete the new branch in the original repository.
             // Note: We cannot delete the branch while we are on it.
             Commands.Checkout(original, "master");
             original.Branches.Remove(newBranch);
-            Assert.IsTrue(clone.FetchRemotes());
+            Assert.That(clone.FetchRemotes(), Is.True,
+                        "The deletion of the branch must have been fetched.");
         }
 
         [TearDown]

--- a/Assets/SEETests/TestMedians.cs
+++ b/Assets/SEETests/TestMedians.cs
@@ -12,42 +12,42 @@ namespace SEE.Utils
         public void TestMedianNull()
         {
             ICollection<float> values = null;
-            Assert.Throws<System.ArgumentException>(() => Medians.Median(values));
+            Assert.That(() => Medians.Median(values), Throws.TypeOf<System.ArgumentException>());
         }
 
         [Test]
         public void TestMedianEmpty()
         {
             ICollection<float> values = new List<float>();
-            Assert.Throws<System.ArgumentException>(() => Medians.Median(values));
+            Assert.That(() => Medians.Median(values), Throws.TypeOf<System.ArgumentException>());
         }
 
         [Test]
         public void TestMedianOne()
         {
             ICollection<float> values = new List<float>() { 1 };
-            Assert.AreEqual(1, Medians.Median(values));
+            Assert.That(Medians.Median(values), Is.EqualTo(1f));
         }
 
         [Test]
         public void TestMedianTwo()
         {
             ICollection<float> values = new List<float>() { 1, 3};
-            Assert.AreEqual(2, Medians.Median(values));
+            Assert.That(Medians.Median(values), Is.EqualTo(2f));
         }
 
         [Test]
         public void TestMedianThree()
         {
             ICollection<float> values = new List<float>() { 1, 2, 3 };
-            Assert.AreEqual(2, Medians.Median(values));
+            Assert.That(Medians.Median(values), Is.EqualTo(2f));
         }
 
         [Test]
         public void TestMedianFour()
         {
             ICollection<float> values = new List<float>() { 1, 2, 4, 5};
-            Assert.AreEqual(3, Medians.Median(values));
+            Assert.That(Medians.Median(values), Is.EqualTo(3f));
         }
     }
 }

--- a/Assets/SEETests/TestMergeDiffGraphExtension.cs
+++ b/Assets/SEETests/TestMergeDiffGraphExtension.cs
@@ -58,7 +58,7 @@ namespace SEE.DataModel.DG
         {
             Graph newGraph = null;
             Graph oldGraph = NewEmptyGraph();
-            Assert.Throws<ArgumentNullException>(() => newGraph.MergeDiff(oldGraph));
+            Assert.That(() => newGraph.MergeDiff(oldGraph), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -69,7 +69,8 @@ namespace SEE.DataModel.DG
         {
             Graph newGraph = null;
             Graph oldGraph = NewEmptyGraph();
-            Assert.Throws<ArgumentNullException>(() => MergeDiffGraphExtension.MergeDiff(newGraph, oldGraph));
+            Assert.That(() => MergeDiffGraphExtension.MergeDiff(newGraph, oldGraph),
+                        Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -81,8 +82,8 @@ namespace SEE.DataModel.DG
             Graph newGraph = graph;
             Graph oldGraph = null;
             newGraph.MergeDiff(oldGraph);
-            Assert.AreEqual(3, newGraph.NodeCount);
-            Assert.AreEqual(2, newGraph.EdgeCount);
+            Assert.That(newGraph.NodeCount, Is.EqualTo(3));
+            Assert.That(newGraph.EdgeCount, Is.EqualTo(2));
         }
 
         #region toggle attribute
@@ -127,8 +128,11 @@ namespace SEE.DataModel.DG
         private void TestToggleAttribute(Graph newGraph, Graph oldGraph, GraphElement ge, bool newValue)
         {
             newGraph.MergeDiff(oldGraph);
-            Assert.AreEqual(newValue, ge.HasToggle(ToggleAttribute));
-            Assert.AreEqual(!newValue, ge.HasToggle(ToggleAttribute + MergeDiffGraphExtension.AttributeOldValuePostfix));
+            string oldToggle = ToggleAttribute + MergeDiffGraphExtension.AttributeOldValuePostfix;
+            Assert.That(ge.HasToggle(ToggleAttribute), Is.EqualTo(newValue),
+                        $"Toggle {ToggleAttribute} of {ge.ID}.");
+            Assert.That(ge.HasToggle(oldToggle), Is.EqualTo(!newValue),
+                        $"Toggle {oldToggle} of {ge.ID}.");
         }
 
         #endregion
@@ -274,13 +278,17 @@ namespace SEE.DataModel.DG
         {
             newGraph.MergeDiff(oldGraph);
             {
-                Assert.IsTrue(tryGet(ge, attribute, out T value));
-                Assert.AreEqual(newValue, value);
+                Assert.That(tryGet(ge, attribute, out T value), Is.True,
+                            $"{ge.ID} has no attribute {attribute}.");
+                Assert.That(value, Is.EqualTo(newValue), $"New value of {attribute} in {ge.ID}.");
             }
-            Assert.IsTrue(ge.HasToggle(ChangeMarkers.IsChanged));
+            Assert.That(ge.HasToggle(ChangeMarkers.IsChanged), Is.True,
+                        $"{ge.ID} is not marked as changed.");
             {
-                Assert.IsTrue(tryGet(ge, attribute + MergeDiffGraphExtension.AttributeOldValuePostfix, out T value));
-                Assert.AreEqual(oldValue, value);
+                string oldAttribute = attribute + MergeDiffGraphExtension.AttributeOldValuePostfix;
+                Assert.That(tryGet(ge, oldAttribute, out T value), Is.True,
+                            $"{ge.ID} has no attribute {oldAttribute}.");
+                Assert.That(value, Is.EqualTo(oldValue), $"Old value of {attribute} in {ge.ID}.");
             }
         }
     }

--- a/Assets/SEETests/TestMetricImporter.cs
+++ b/Assets/SEETests/TestMetricImporter.cs
@@ -41,7 +41,7 @@ namespace SEE.DataModel.DG.IO
                 }
                 catch (System.IO.IOException ex)
                 {
-                    Assert.AreEqual($"First header column in {path.Path} is not ID.", ex.Message);
+                    Assert.That(ex.Message, Is.EqualTo($"First header column in {path.Path} is not ID."));
                     // This is expected.
                     // Note: I couldn't use the following:
                     // Assert.ThrowsAsync<IOException>(async () => await MetricImporter.LoadCsvAsync(new Graph(""), path));

--- a/Assets/SEETests/TestNonIncrementalReflexionAnalysis.cs
+++ b/Assets/SEETests/TestNonIncrementalReflexionAnalysis.cs
@@ -273,12 +273,17 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
 
             // 1 implicitly allowed propagated dependency
-            Assert.That(IsImplicitlyAllowed(fromImpl, toImpl, call));
+            Assert.That(IsImplicitlyAllowed(fromImpl, toImpl, call), Is.True,
+                        $"Edge {fromImpl.ID} -> {toImpl.ID} must have changed to state ImplicitlyAllowed.");
             // 4 absences
-            Assert.That(IsAbsent(N2, N1, call));
-            Assert.That(IsAbsent(N1_C1, N2_C1, call));
-            Assert.That(IsAbsent(N3, N1_C2, call));
-            Assert.That(IsAllowedAbsent(N3, N2_C1, call));
+            Assert.That(IsAbsent(N2, N1, call), Is.True,
+                        $"Edge {N2.ID} -> {N1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N1_C1, N2_C1, call), Is.True,
+                        $"Edge {N1_C1.ID} -> {N2_C1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N3, N1_C2, call), Is.True,
+                        $"Edge {N3.ID} -> {N1_C2.ID} must have changed to state Absent.");
+            Assert.That(IsAllowedAbsent(N3, N2_C1, call), Is.True,
+                        $"Edge {N3.ID} -> {N2_C1.ID} must have changed to state AllowedAbsent.");
             // 0 divergences
             AssertEventCountEquals<EdgeChange>(5);
 
@@ -336,10 +341,14 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
 
             // 4 absences
-            Assert.That(IsAbsent(N2, N1, call));
-            Assert.That(IsAbsent(N1_C1, N2_C1, call));
-            Assert.That(IsAbsent(N3, N1_C2, call));
-            Assert.That(IsAllowedAbsent(N3, N2_C1, call));
+            Assert.That(IsAbsent(N2, N1, call), Is.True,
+                        $"Edge {N2.ID} -> {N1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N1_C1, N2_C1, call), Is.True,
+                        $"Edge {N1_C1.ID} -> {N2_C1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N3, N1_C2, call), Is.True,
+                        $"Edge {N3.ID} -> {N1_C2.ID} must have changed to state Absent.");
+            Assert.That(IsAllowedAbsent(N3, N2_C1, call), Is.True,
+                        $"Edge {N3.ID} -> {N2_C1.ID} must have changed to state AllowedAbsent.");
             // 0 divergences
             AssertEventCountEquals<EdgeChange>(5);
 
@@ -355,7 +364,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 implicitly allowed propagated dependencies
-            Assert.That(IsImplicitlyAllowed(n1_c1, n1, call));
+            Assert.That(IsImplicitlyAllowed(n1_c1, n1, call), Is.True,
+                        $"Edge {n1_c1.ID} -> {n1.ID} must have changed to state ImplicitlyAllowed.");
             CommonHierarchyAccess();
         }
 
@@ -368,7 +378,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 implicitly allowed propagated dependencies
-            Assert.That(IsImplicitlyAllowed(n1_c1_c1, n1, call));
+            Assert.That(IsImplicitlyAllowed(n1_c1_c1, n1, call), Is.True,
+                        $"Edge {n1_c1_c1.ID} -> {n1.ID} must have changed to state ImplicitlyAllowed.");
             CommonHierarchyAccess();
         }
 
@@ -380,7 +391,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 implicitly allowed propagated dependencies
-            Assert.That(IsImplicitlyAllowed(n1_c1, n1_c1_c1, call));
+            Assert.That(IsImplicitlyAllowed(n1_c1, n1_c1_c1, call), Is.True,
+                        $"Edge {n1_c1.ID} -> {n1_c1_c1.ID} must have changed to state ImplicitlyAllowed.");
             CommonHierarchyAccess();
         }
 
@@ -392,7 +404,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 disallowed propagated dependencies
-            Assert.That(IsDivergent(n1, n1_c1, call));
+            Assert.That(IsDivergent(n1, n1_c1, call), Is.True,
+                        $"Edge {n1.ID} -> {n1_c1.ID} must have changed to state Divergent.");
             CommonHierarchyAccess();
         }
 
@@ -416,17 +429,26 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(4, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
 
             // 4 convergences
-            Assert.That(IsConvergent(N2, N1, call));
-            Assert.That(IsConvergent(N1_C1, N2_C1, call));
-            Assert.That(IsConvergent(N3, N1_C2, call));
-            Assert.That(IsConvergent(N3, N2_C1, call));
+            Assert.That(IsConvergent(N2, N1, call), Is.True,
+                        $"Edge {N2.ID} -> {N1.ID} must have changed to state Convergent.");
+            Assert.That(IsConvergent(N1_C1, N2_C1, call), Is.True,
+                        $"Edge {N1_C1.ID} -> {N2_C1.ID} must have changed to state Convergent.");
+            Assert.That(IsConvergent(N3, N1_C2, call), Is.True,
+                        $"Edge {N3.ID} -> {N1_C2.ID} must have changed to state Convergent.");
+            Assert.That(IsConvergent(N3, N2_C1, call), Is.True,
+                        $"Edge {N3.ID} -> {N2_C1.ID} must have changed to state Convergent.");
 
             // 5 allowed propagated dependencies
-            Assert.That(IsAllowed(n1_c1_c1, n2_c1, call));
-            Assert.That(IsAllowed(n1_c1_c2, n2_c1, call));
-            Assert.That(IsAllowed(n2, n1_c2, call));
-            Assert.That(IsAllowed(n3, n2_c1, call));
-            Assert.That(IsAllowed(n3, n1_c2, call));
+            Assert.That(IsAllowed(n1_c1_c1, n2_c1, call), Is.True,
+                        $"Edge {n1_c1_c1.ID} -> {n2_c1.ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(n1_c1_c2, n2_c1, call), Is.True,
+                        $"Edge {n1_c1_c2.ID} -> {n2_c1.ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(n2, n1_c2, call), Is.True,
+                        $"Edge {n2.ID} -> {n1_c2.ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(n3, n2_c1, call), Is.True,
+                        $"Edge {n3.ID} -> {n2_c1.ID} must have changed to state Allowed.");
+            Assert.That(IsAllowed(n3, n1_c2, call), Is.True,
+                        $"Edge {n3.ID} -> {n1_c2.ID} must have changed to state Allowed.");
             // 0 absences
 
             // 0 divergences
@@ -446,13 +468,18 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
 
             // 1 convergences
-            Assert.That(IsConvergent(N2, N1, call));
+            Assert.That(IsConvergent(N2, N1, call), Is.True,
+                        $"Edge {N2.ID} -> {N1.ID} must have changed to state Convergent.");
             // 1 allowed propagated dependencies
-            Assert.That(IsAllowed(n2, n1, call));
+            Assert.That(IsAllowed(n2, n1, call), Is.True,
+                        $"Edge {n2.ID} -> {n1.ID} must have changed to state Allowed.");
             // 3 absences
-            Assert.That(IsAbsent(N1_C1, N2_C1, call));
-            Assert.That(IsAbsent(N3, N1_C2, call));
-            Assert.That(IsAllowedAbsent(N3, N2_C1, call));
+            Assert.That(IsAbsent(N1_C1, N2_C1, call), Is.True,
+                        $"Edge {N1_C1.ID} -> {N2_C1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N3, N1_C2, call), Is.True,
+                        $"Edge {N3.ID} -> {N1_C2.ID} must have changed to state Absent.");
+            Assert.That(IsAllowedAbsent(N3, N2_C1, call), Is.True,
+                        $"Edge {N3.ID} -> {N2_C1.ID} must have changed to state AllowedAbsent.");
             // 0 divergences
             AssertEventCountEquals<EdgeChange>(5);
             // 0 removed edges
@@ -465,11 +492,15 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
 
             // 1 convergences
-            Assert.That(IsConvergent(N2, N1, call));
+            Assert.That(IsConvergent(N2, N1, call), Is.True,
+                        $"Edge {N2.ID} -> {N1.ID} must have changed to state Convergent.");
             // 3 absences
-            Assert.That(IsAbsent(N1_C1, N2_C1, call));
-            Assert.That(IsAbsent(N3, N1_C2, call));
-            Assert.That(IsAllowedAbsent(N3, N2_C1, call));
+            Assert.That(IsAbsent(N1_C1, N2_C1, call), Is.True,
+                        $"Edge {N1_C1.ID} -> {N2_C1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N3, N1_C2, call), Is.True,
+                        $"Edge {N3.ID} -> {N1_C2.ID} must have changed to state Absent.");
+            Assert.That(IsAllowedAbsent(N3, N2_C1, call), Is.True,
+                        $"Edge {N3.ID} -> {N2_C1.ID} must have changed to state AllowedAbsent.");
             // 0 divergences
             AssertEventCountEquals<EdgeChange>(5);
             // 0 removed edges
@@ -483,7 +514,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 allowed propagated dependencies
-            Assert.That(IsAllowed(n2_c1, n1_c2, call));
+            Assert.That(IsAllowed(n2_c1, n1_c2, call), Is.True,
+                        $"Edge {n2_c1.ID} -> {n1_c2.ID} must have changed to state Allowed.");
 
             CommonTestConvergences345();
         }
@@ -495,7 +527,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 allowed propagated dependencies
-            Assert.That(IsAllowed(n2_c1, n1_c1_c2, call));
+            Assert.That(IsAllowed(n2_c1, n1_c1_c2, call), Is.True,
+                        $"Edge {n2_c1.ID} -> {n1_c1_c2.ID} must have changed to state Allowed.");
 
             CommonTestConvergences345();
         }
@@ -507,7 +540,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 allowed propagated dependencies
-            Assert.That(IsAllowed(n2_c1, n1, call));
+            Assert.That(IsAllowed(n2_c1, n1, call), Is.True,
+                        $"Edge {n2_c1.ID} -> {n1.ID} must have changed to state Allowed.");
 
             CommonTestConvergences345();
         }
@@ -522,10 +556,14 @@ namespace SEE.Tools.Architecture
             AssertEventCountEquals<EdgeEvent>(1, ChangeType.Addition, ReflexionSubgraphs.Architecture, ignorePropagated: false);
 
             // 4 absences
-            Assert.That(IsAbsent(N2, N1, call));
-            Assert.That(IsAbsent(N1_C1, N2_C1, call));
-            Assert.That(IsAbsent(N3, N1_C2, call));
-            Assert.That(IsAllowedAbsent(N3, N2_C1, call));
+            Assert.That(IsAbsent(N2, N1, call), Is.True,
+                        $"Edge {N2.ID} -> {N1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N1_C1, N2_C1, call), Is.True,
+                        $"Edge {N1_C1.ID} -> {N2_C1.ID} must have changed to state Absent.");
+            Assert.That(IsAbsent(N3, N1_C2, call), Is.True,
+                        $"Edge {N3.ID} -> {N1_C2.ID} must have changed to state Absent.");
+            Assert.That(IsAllowedAbsent(N3, N2_C1, call), Is.True,
+                        $"Edge {N3.ID} -> {N2_C1.ID} must have changed to state AllowedAbsent.");
             // 0 convergences
             AssertEventCountEquals<EdgeChange>(4 + divergences);
 
@@ -540,7 +578,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 divergent propagated dependency
-            Assert.That(IsDivergent(n1, n2, call));
+            Assert.That(IsDivergent(n1, n2, call), Is.True,
+                        $"Edge {n1.ID} -> {n2.ID} must have changed to state Divergent.");
 
             CommonAbsences();
         }
@@ -552,7 +591,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 divergent propagated dependency
-            Assert.That(IsDivergent(n1_c1, n2, call));
+            Assert.That(IsDivergent(n1_c1, n2, call), Is.True,
+                        $"Edge {n1_c1.ID} -> {n2.ID} must have changed to state Divergent.");
 
             CommonAbsences();
         }
@@ -565,8 +605,10 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 2 divergent propagated dependencies
-            Assert.That(IsDivergent(n1_c1_c1, n2, call));
-            Assert.That(IsDivergent(n1_c1_c2, n2, call));
+            Assert.That(IsDivergent(n1_c1_c1, n2, call), Is.True,
+                        $"Edge {n1_c1_c1.ID} -> {n2.ID} must have changed to state Divergent.");
+            Assert.That(IsDivergent(n1_c1_c2, n2, call), Is.True,
+                        $"Edge {n1_c1_c2.ID} -> {n2.ID} must have changed to state Divergent.");
 
             CommonAbsences(2);
         }
@@ -578,7 +620,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 divergent propagated dependency
-            Assert.That(IsDivergent(n1, n2_c1, call));
+            Assert.That(IsDivergent(n1, n2_c1, call), Is.True,
+                        $"Edge {n1.ID} -> {n2_c1.ID} must have changed to state Divergent.");
 
             CommonAbsences();
         }
@@ -590,7 +633,8 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 divergent propagated dependency
-            Assert.That(IsDivergent(n1_c2, n2_c1, call));
+            Assert.That(IsDivergent(n1_c2, n2_c1, call), Is.True,
+                        $"Edge {n1_c2.ID} -> {n2_c1.ID} must have changed to state Divergent.");
 
             CommonAbsences();
         }
@@ -603,8 +647,10 @@ namespace SEE.Tools.Architecture
             graph.RunAnalysis();
 
             // 1 divergent propagated dependency
-            Assert.That(IsDivergent(n1_c1_c1, n1_c2, call));
-            Assert.That(IsDivergent(n1_c1_c2, n1_c2, call));
+            Assert.That(IsDivergent(n1_c1_c1, n1_c2, call), Is.True,
+                        $"Edge {n1_c1_c1.ID} -> {n1_c2.ID} must have changed to state Divergent.");
+            Assert.That(IsDivergent(n1_c1_c2, n1_c2, call), Is.True,
+                        $"Edge {n1_c1_c2.ID} -> {n1_c2.ID} must have changed to state Divergent.");
 
             CommonAbsences(2);
         }

--- a/Assets/SEETests/TestPathGlobbing.cs
+++ b/Assets/SEETests/TestPathGlobbing.cs
@@ -10,101 +10,96 @@ namespace SEE.Utils
     {
         private const string helloC = "hello.c";
 
-        private static List<string> EmptyList => new();
-
         private readonly List<string> hellos = new() { helloC, "hello.cpp", "hello.cs", "helloc" };
 
         [Test]
         public void TestFilterSimple()
         {
-            Assert.AreEqual(new List<string>() { helloC },
-                            PathGlobbing.Filter(hellos, new Globbing() { { "*.c", true } }));
+            Assert.That(PathGlobbing.Filter(hellos, new Globbing() { { "*.c", true } }),
+                        Is.EqualTo(new List<string>() { helloC }));
         }
 
         [Test]
         public void TestContraDictingFilter1()
         {
-            Assert.AreEqual(new List<string>(),
-                            PathGlobbing.Filter(hellos, new Globbing() { { "*.c", true }, { helloC, false } }));
+            Assert.That(PathGlobbing.Filter(hellos, new Globbing() { { "*.c", true }, { helloC, false } }),
+                        Is.Empty);
         }
 
         [Test]
         public void TestContraDictingFilter2()
         {
-            Assert.AreEqual(EmptyList,
-                            PathGlobbing.Filter(hellos, new Globbing() { { "*.c", false }, { helloC, true } }));
+            Assert.That(PathGlobbing.Filter(hellos, new Globbing() { { "*.c", false }, { helloC, true } }),
+                        Is.Empty);
         }
 
         [Test]
         public void TestContraDictingFilter3()
         {
-            Assert.AreEqual(EmptyList,
-                            PathGlobbing.Filter(hellos, new Globbing() { { helloC, true }, { "*.c", false } }));
+            Assert.That(PathGlobbing.Filter(hellos, new Globbing() { { helloC, true }, { "*.c", false } }),
+                        Is.Empty);
         }
 
         [Test]
         public void TestContraDictingFilter4()
         {
-            Assert.AreEqual(EmptyList,
-                            PathGlobbing.Filter(hellos, new Globbing() { { helloC, false }, { "*.c", true } }));
+            Assert.That(PathGlobbing.Filter(hellos, new Globbing() { { helloC, false }, { "*.c", true } }),
+                        Is.Empty);
         }
 
         [Test]
         public void TestNullGlobbing()
         {
-            Assert.AreEqual(hellos,
-                            PathGlobbing.Filter(hellos, pathGlobbing: null));
+            Assert.That(PathGlobbing.Filter(hellos, pathGlobbing: null), Is.EqualTo(hellos));
         }
 
         [Test]
         public void TestEmptyGlobbing()
         {
-            Assert.AreEqual(EmptyList,
-                            PathGlobbing.Filter(hellos, pathGlobbing: new Globbing()));
+            Assert.That(PathGlobbing.Filter(hellos, pathGlobbing: new Globbing()), Is.Empty);
         }
 
         [Test]
         public void TestNullPaths1()
         {
-            Assert.Throws<System.ArgumentNullException>
-                (() => PathGlobbing.Filter(null, pathGlobbing: new Globbing()));
+            Assert.That(() => PathGlobbing.Filter(null, pathGlobbing: new Globbing()),
+                        Throws.ArgumentNullException);
         }
 
         [Test]
         public void TestNullPaths2()
         {
-            Assert.Throws<System.ArgumentNullException>
-                (() => PathGlobbing.Filter(null, pathGlobbing: null));
+            Assert.That(() => PathGlobbing.Filter(null, pathGlobbing: null),
+                        Throws.ArgumentNullException);
         }
 
         [Test]
         public void TestToMatcher()
         {
-            Assert.AreEqual(new List<string>() { helloC },
-                            PathGlobbing.Filter
-                               (hellos,
-                                PathGlobbing.ToMatcher(new Globbing() { { "*.c", true } })));
+            Assert.That(PathGlobbing.Filter
+                            (hellos,
+                             PathGlobbing.ToMatcher(new Globbing() { { "*.c", true } })),
+                        Is.EqualTo(new List<string>() { helloC }));
         }
 
         [Test]
         public void TestEmptyMatcher()
         {
-            Assert.AreEqual(EmptyList,
-                            PathGlobbing.Filter(hellos, matcher: new()));
+            Assert.That(PathGlobbing.Filter(hellos, matcher: new()), Is.Empty);
         }
 
         [Test]
         public void TestNullPathsMatcher1()
         {
-            Assert.Throws<System.ArgumentNullException>
-                (() => PathGlobbing.Filter(null, matcher: new ()));
+            Assert.That(() => PathGlobbing.Filter(null, matcher: new()),
+                        Throws.ArgumentNullException);
         }
 
         [Test]
         public void TestNullPathsMatcher2()
         {
-            Assert.Throws<System.ArgumentNullException>
-                (() => PathGlobbing.Filter(null, matcher: null));
+            Assert.That(() => PathGlobbing.Filter(null, matcher: null),
+                        Throws.ArgumentNullException);
         }
     }
 }

--- a/Assets/SEETests/TestRandomTrees.cs
+++ b/Assets/SEETests/TestRandomTrees.cs
@@ -20,8 +20,8 @@ namespace SEE.Utils
             // empty tree requested
             int n = 0;
             int[] parent = RandomTrees.Random(n, out int root);
-            Assert.AreEqual(n, parent.Length);
-            Assert.AreEqual(-1, root);
+            Assert.That(parent, Has.Length.EqualTo(n));
+            Assert.That(root, Is.EqualTo(-1));
         }
 
         [Test]
@@ -30,9 +30,9 @@ namespace SEE.Utils
             // tree with single node requested
             int n = 1;
             int[] parent = RandomTrees.Random(n, out int root);
-            Assert.AreEqual(n, parent.Length);
-            Assert.AreEqual(-1, parent[0]);
-            Assert.AreEqual(0, root);
+            Assert.That(parent, Has.Length.EqualTo(n));
+            Assert.That(parent[0], Is.EqualTo(-1));
+            Assert.That(root, Is.EqualTo(0));
         }
 
         private void AssertTree(int[] parent, int root)
@@ -42,26 +42,22 @@ namespace SEE.Utils
             for (int i = 0; i < parent.Length; i++)
             {
                 int node = parent[i];
-                Assert.That(node >= -1);
-                Assert.That(node < parent.Length);
+                Assert.That(node, Is.InRange(-1, parent.Length - 1));
                 if (node == -1)
                 {
-                    Assert.That(i == root);
+                    Assert.That(i, Is.EqualTo(root), "Only the root may have -1 as its parent.");
                 }
             }
             // default for bool in C# is false
             bool[] visited = new bool[parent.Length];
             Visit(root, parent, visited);
             // Make sure every node was visited.
-            foreach (bool v in visited)
-            {
-                Assert.That(v);
-            }
+            Assert.That(visited, Is.All.True);
         }
 
         private void Visit(int node, int[] parent, bool[] visited)
         {
-            Assert.That(!visited[node]);
+            Assert.That(visited[node], Is.False, $"Node {node} was visited more than once.");
             visited[node] = true;
             for (int i = 0; i < parent.Length; i++)
             {
@@ -80,8 +76,8 @@ namespace SEE.Utils
             for (int n = 2; n <= 100; n++)
             {
                 int[] parent = RandomTrees.Random(n, out int root);
-                Assert.AreEqual(n, parent.Length);
-                Assert.AreEqual(-1, parent[root]);
+                Assert.That(parent, Has.Length.EqualTo(n));
+                Assert.That(parent[root], Is.EqualTo(-1));
                 AssertTree(parent, root);
             }
         }

--- a/Assets/SEETests/TestRanges.cs
+++ b/Assets/SEETests/TestRanges.cs
@@ -12,16 +12,16 @@ namespace SEE.DataModel.DG
         [Test]
         public void TestLines()
         {
-            Assert.AreEqual(1, OneFullLine.Lines);
-            Assert.AreEqual(2, TwoFullLines.Lines);
-            Assert.AreEqual(1, OneCharacter.Lines);
-            Assert.AreEqual(1, HalfALineStart.Lines);
-            Assert.AreEqual(1, HalfALineEnd.Lines);
-            Assert.AreEqual(2, OneAndAHalfEndLine.Lines);
-            Assert.AreEqual(2, OneAndAHalfStartLine.Lines);
-            Assert.AreEqual(3, OneAndTwoHalfLines.Lines);
-            Assert.AreEqual(100, LargeRange.Lines);
-            Assert.AreEqual(301, LargeLineRange.Lines);
+            Assert.That(OneFullLine.Lines, Is.EqualTo(1));
+            Assert.That(TwoFullLines.Lines, Is.EqualTo(2));
+            Assert.That(OneCharacter.Lines, Is.EqualTo(1));
+            Assert.That(HalfALineStart.Lines, Is.EqualTo(1));
+            Assert.That(HalfALineEnd.Lines, Is.EqualTo(1));
+            Assert.That(OneAndAHalfEndLine.Lines, Is.EqualTo(2));
+            Assert.That(OneAndAHalfStartLine.Lines, Is.EqualTo(2));
+            Assert.That(OneAndTwoHalfLines.Lines, Is.EqualTo(3));
+            Assert.That(LargeRange.Lines, Is.EqualTo(100));
+            Assert.That(LargeLineRange.Lines, Is.EqualTo(301));
         }
 
         /// <summary>
@@ -49,20 +49,24 @@ namespace SEE.DataModel.DG
         [Test]
         public void TestCompare()
         {
-            Assert.IsTrue(ComparisonMatrix.GetLength(0) == AllRanges.Count);
-            Assert.IsTrue(ComparisonMatrix.Rank == 2);
+            Assert.That(ComparisonMatrix.GetLength(0), Is.EqualTo(AllRanges.Count),
+                        "The comparison matrix must have one row per example range.");
+            Assert.That(ComparisonMatrix.Rank, Is.EqualTo(2),
+                        "The comparison matrix must be two-dimensional.");
 
             for (int i = 0; i < ComparisonMatrix.GetLength(0); i++)
             {
-                Assert.IsTrue(ComparisonMatrix.GetLength(1) == AllRanges.Count);
+                Assert.That(ComparisonMatrix.GetLength(1), Is.EqualTo(AllRanges.Count),
+                            "The comparison matrix must have one column per example range.");
                 for (int j = 0; j < ComparisonMatrix.GetLength(1); j++)
                 {
                     Range firstRange = AllRanges[i];
                     Range secondRange = AllRanges[j];
                     int comparison = ComparisonMatrix[i, j];
                     int actual = firstRange.CompareTo(secondRange);
-                    Assert.AreEqual(comparison, actual, $"Expected {firstRange} {ComparisonToSymbol(comparison)} "
-                                    + $"{secondRange}, but got {ComparisonToSymbol(actual)} instead.");
+                    Assert.That(actual, Is.EqualTo(comparison),
+                                $"Expected {firstRange} {ComparisonToSymbol(comparison)} "
+                                + $"{secondRange}, but got {ComparisonToSymbol(actual)} instead.");
                 }
             }
         }
@@ -82,91 +86,91 @@ namespace SEE.DataModel.DG
         [Test]
         public void TestContainsPoint()
         {
-            Assert.IsFalse(OneFullLine.Contains(0, 0));
-            Assert.IsFalse(OneFullLine.Contains(0, 5));
-            Assert.IsTrue(OneFullLine.Contains(1, 0));
-            Assert.IsTrue(OneFullLine.Contains(1, 1));
-            Assert.IsTrue(OneFullLine.Contains(1, 10));
-            Assert.IsFalse(OneFullLine.Contains(2, 0));
+            Assert.That(OneFullLine.Contains(0, 0), Is.False, $"{OneFullLine} must not contain 0:0.");
+            Assert.That(OneFullLine.Contains(0, 5), Is.False, $"{OneFullLine} must not contain 0:5.");
+            Assert.That(OneFullLine.Contains(1, 0), Is.True, $"{OneFullLine} must contain 1:0.");
+            Assert.That(OneFullLine.Contains(1, 1), Is.True, $"{OneFullLine} must contain 1:1.");
+            Assert.That(OneFullLine.Contains(1, 10), Is.True, $"{OneFullLine} must contain 1:10.");
+            Assert.That(OneFullLine.Contains(2, 0), Is.False, $"{OneFullLine} must not contain 2:0.");
 
-            Assert.IsFalse(OneFullLine.Contains(0, 0));
-            Assert.IsFalse(OneFullLine.Contains(0, 5));
-            Assert.IsTrue(TwoFullLines.Contains(1, 0));
-            Assert.IsTrue(TwoFullLines.Contains(1, 1));
-            Assert.IsTrue(TwoFullLines.Contains(1, 10));
-            Assert.IsTrue(TwoFullLines.Contains(2, 0));
-            Assert.IsTrue(TwoFullLines.Contains(2, 5));
-            Assert.IsFalse(TwoFullLines.Contains(3, 0));
-            Assert.IsFalse(OneFullLine.Contains(3, 5));
+            Assert.That(OneFullLine.Contains(0, 0), Is.False, $"{OneFullLine} must not contain 0:0.");
+            Assert.That(OneFullLine.Contains(0, 5), Is.False, $"{OneFullLine} must not contain 0:5.");
+            Assert.That(TwoFullLines.Contains(1, 0), Is.True, $"{TwoFullLines} must contain 1:0.");
+            Assert.That(TwoFullLines.Contains(1, 1), Is.True, $"{TwoFullLines} must contain 1:1.");
+            Assert.That(TwoFullLines.Contains(1, 10), Is.True, $"{TwoFullLines} must contain 1:10.");
+            Assert.That(TwoFullLines.Contains(2, 0), Is.True, $"{TwoFullLines} must contain 2:0.");
+            Assert.That(TwoFullLines.Contains(2, 5), Is.True, $"{TwoFullLines} must contain 2:5.");
+            Assert.That(TwoFullLines.Contains(3, 0), Is.False, $"{TwoFullLines} must not contain 3:0.");
+            Assert.That(OneFullLine.Contains(3, 5), Is.False, $"{OneFullLine} must not contain 3:5.");
 
-            Assert.IsFalse(OneCharacter.Contains(0, 0));
-            Assert.IsFalse(OneCharacter.Contains(1, 1));
-            Assert.IsTrue(OneCharacter.Contains(1, 2));
-            Assert.IsFalse(OneCharacter.Contains(1, 3));
-            Assert.IsFalse(OneCharacter.Contains(1, 4));
-            Assert.IsFalse(OneCharacter.Contains(2, 0));
+            Assert.That(OneCharacter.Contains(0, 0), Is.False, $"{OneCharacter} must not contain 0:0.");
+            Assert.That(OneCharacter.Contains(1, 1), Is.False, $"{OneCharacter} must not contain 1:1.");
+            Assert.That(OneCharacter.Contains(1, 2), Is.True, $"{OneCharacter} must contain 1:2.");
+            Assert.That(OneCharacter.Contains(1, 3), Is.False, $"{OneCharacter} must not contain 1:3.");
+            Assert.That(OneCharacter.Contains(1, 4), Is.False, $"{OneCharacter} must not contain 1:4.");
+            Assert.That(OneCharacter.Contains(2, 0), Is.False, $"{OneCharacter} must not contain 2:0.");
 
-            Assert.IsFalse(HalfALineStart.Contains(0, 0));
-            Assert.IsFalse(HalfALineStart.Contains(0, 5));
-            Assert.IsTrue(HalfALineStart.Contains(1, 0));
-            Assert.IsTrue(HalfALineStart.Contains(1, 1));
-            Assert.IsTrue(HalfALineStart.Contains(1, 3));
-            Assert.IsFalse(HalfALineStart.Contains(1, 4));
-            Assert.IsFalse(HalfALineStart.Contains(2, 0));
+            Assert.That(HalfALineStart.Contains(0, 0), Is.False, $"{HalfALineStart} must not contain 0:0.");
+            Assert.That(HalfALineStart.Contains(0, 5), Is.False, $"{HalfALineStart} must not contain 0:5.");
+            Assert.That(HalfALineStart.Contains(1, 0), Is.True, $"{HalfALineStart} must contain 1:0.");
+            Assert.That(HalfALineStart.Contains(1, 1), Is.True, $"{HalfALineStart} must contain 1:1.");
+            Assert.That(HalfALineStart.Contains(1, 3), Is.True, $"{HalfALineStart} must contain 1:3.");
+            Assert.That(HalfALineStart.Contains(1, 4), Is.False, $"{HalfALineStart} must not contain 1:4.");
+            Assert.That(HalfALineStart.Contains(2, 0), Is.False, $"{HalfALineStart} must not contain 2:0.");
 
-            Assert.IsFalse(HalfALineEnd.Contains(0, 0));
-            Assert.IsFalse(HalfALineEnd.Contains(0, 5));
-            Assert.IsFalse(HalfALineEnd.Contains(1, 4));
-            Assert.IsTrue(HalfALineEnd.Contains(1, 5));
-            Assert.IsFalse(HalfALineEnd.Contains(2, 0));
-            Assert.IsFalse(HalfALineEnd.Contains(2, 1));
+            Assert.That(HalfALineEnd.Contains(0, 0), Is.False, $"{HalfALineEnd} must not contain 0:0.");
+            Assert.That(HalfALineEnd.Contains(0, 5), Is.False, $"{HalfALineEnd} must not contain 0:5.");
+            Assert.That(HalfALineEnd.Contains(1, 4), Is.False, $"{HalfALineEnd} must not contain 1:4.");
+            Assert.That(HalfALineEnd.Contains(1, 5), Is.True, $"{HalfALineEnd} must contain 1:5.");
+            Assert.That(HalfALineEnd.Contains(2, 0), Is.False, $"{HalfALineEnd} must not contain 2:0.");
+            Assert.That(HalfALineEnd.Contains(2, 1), Is.False, $"{HalfALineEnd} must not contain 2:1.");
 
-            Assert.IsTrue(OneAndAHalfEndLine.Contains(1, 0));
-            Assert.IsTrue(OneAndAHalfEndLine.Contains(1, 5));
-            Assert.IsTrue(OneAndAHalfEndLine.Contains(1, 6));
-            Assert.IsTrue(OneAndAHalfEndLine.Contains(1, 7));
-            Assert.IsTrue(OneAndAHalfEndLine.Contains(2, 0));
-            Assert.IsTrue(OneAndAHalfEndLine.Contains(2, 5));
-            Assert.IsFalse(OneAndAHalfEndLine.Contains(2, 6));
-            Assert.IsFalse(OneAndAHalfEndLine.Contains(3, 0));
+            Assert.That(OneAndAHalfEndLine.Contains(1, 0), Is.True, $"{OneAndAHalfEndLine} must contain 1:0.");
+            Assert.That(OneAndAHalfEndLine.Contains(1, 5), Is.True, $"{OneAndAHalfEndLine} must contain 1:5.");
+            Assert.That(OneAndAHalfEndLine.Contains(1, 6), Is.True, $"{OneAndAHalfEndLine} must contain 1:6.");
+            Assert.That(OneAndAHalfEndLine.Contains(1, 7), Is.True, $"{OneAndAHalfEndLine} must contain 1:7.");
+            Assert.That(OneAndAHalfEndLine.Contains(2, 0), Is.True, $"{OneAndAHalfEndLine} must contain 2:0.");
+            Assert.That(OneAndAHalfEndLine.Contains(2, 5), Is.True, $"{OneAndAHalfEndLine} must contain 2:5.");
+            Assert.That(OneAndAHalfEndLine.Contains(2, 6), Is.False, $"{OneAndAHalfEndLine} must not contain 2:6.");
+            Assert.That(OneAndAHalfEndLine.Contains(3, 0), Is.False, $"{OneAndAHalfEndLine} must not contain 3:0.");
 
-            Assert.IsFalse(OneAndAHalfStartLine.Contains(1, 6));
-            Assert.IsTrue(OneAndAHalfStartLine.Contains(1, 7));
-            Assert.IsTrue(OneAndAHalfStartLine.Contains(1, 9));
-            Assert.IsTrue(OneAndAHalfStartLine.Contains(2, 0));
-            Assert.IsTrue(OneAndAHalfStartLine.Contains(2, 9));
-            Assert.IsFalse(OneAndAHalfStartLine.Contains(3, 0));
-            Assert.IsFalse(OneAndAHalfStartLine.Contains(3, 5));
+            Assert.That(OneAndAHalfStartLine.Contains(1, 6), Is.False, $"{OneAndAHalfStartLine} must not contain 1:6.");
+            Assert.That(OneAndAHalfStartLine.Contains(1, 7), Is.True, $"{OneAndAHalfStartLine} must contain 1:7.");
+            Assert.That(OneAndAHalfStartLine.Contains(1, 9), Is.True, $"{OneAndAHalfStartLine} must contain 1:9.");
+            Assert.That(OneAndAHalfStartLine.Contains(2, 0), Is.True, $"{OneAndAHalfStartLine} must contain 2:0.");
+            Assert.That(OneAndAHalfStartLine.Contains(2, 9), Is.True, $"{OneAndAHalfStartLine} must contain 2:9.");
+            Assert.That(OneAndAHalfStartLine.Contains(3, 0), Is.False, $"{OneAndAHalfStartLine} must not contain 3:0.");
+            Assert.That(OneAndAHalfStartLine.Contains(3, 5), Is.False, $"{OneAndAHalfStartLine} must not contain 3:5.");
 
-            Assert.IsFalse(OneAndTwoHalfLines.Contains(1, 4));
-            Assert.IsTrue(OneAndTwoHalfLines.Contains(1, 5));
-            Assert.IsTrue(OneAndTwoHalfLines.Contains(1, 6));
-            Assert.IsTrue(OneAndTwoHalfLines.Contains(2, 5));
-            Assert.IsTrue(OneAndTwoHalfLines.Contains(2, 6));
-            Assert.IsTrue(OneAndTwoHalfLines.Contains(3, 4));
-            Assert.IsFalse(OneAndTwoHalfLines.Contains(3, 5));
+            Assert.That(OneAndTwoHalfLines.Contains(1, 4), Is.False, $"{OneAndTwoHalfLines} must not contain 1:4.");
+            Assert.That(OneAndTwoHalfLines.Contains(1, 5), Is.True, $"{OneAndTwoHalfLines} must contain 1:5.");
+            Assert.That(OneAndTwoHalfLines.Contains(1, 6), Is.True, $"{OneAndTwoHalfLines} must contain 1:6.");
+            Assert.That(OneAndTwoHalfLines.Contains(2, 5), Is.True, $"{OneAndTwoHalfLines} must contain 2:5.");
+            Assert.That(OneAndTwoHalfLines.Contains(2, 6), Is.True, $"{OneAndTwoHalfLines} must contain 2:6.");
+            Assert.That(OneAndTwoHalfLines.Contains(3, 4), Is.True, $"{OneAndTwoHalfLines} must contain 3:4.");
+            Assert.That(OneAndTwoHalfLines.Contains(3, 5), Is.False, $"{OneAndTwoHalfLines} must not contain 3:5.");
 
-            Assert.IsFalse(LargeRange.Contains(0, 0));
-            Assert.IsFalse(LargeRange.Contains(0, 50));
-            Assert.IsFalse(LargeRange.Contains(1, 0));
-            Assert.IsFalse(LargeRange.Contains(1, 2));
-            Assert.IsTrue(LargeRange.Contains(1, 3));
-            Assert.IsTrue(LargeRange.Contains(1, 99));
-            Assert.IsTrue(LargeRange.Contains(1, 100));
-            Assert.IsTrue(LargeRange.Contains(1, 150));
-            Assert.IsTrue(LargeRange.Contains(100, 3));
-            Assert.IsTrue(LargeRange.Contains(100, 99));
-            Assert.IsFalse(LargeRange.Contains(100, 100));
-            Assert.IsFalse(LargeRange.Contains(100, 150));
+            Assert.That(LargeRange.Contains(0, 0), Is.False, $"{LargeRange} must not contain 0:0.");
+            Assert.That(LargeRange.Contains(0, 50), Is.False, $"{LargeRange} must not contain 0:50.");
+            Assert.That(LargeRange.Contains(1, 0), Is.False, $"{LargeRange} must not contain 1:0.");
+            Assert.That(LargeRange.Contains(1, 2), Is.False, $"{LargeRange} must not contain 1:2.");
+            Assert.That(LargeRange.Contains(1, 3), Is.True, $"{LargeRange} must contain 1:3.");
+            Assert.That(LargeRange.Contains(1, 99), Is.True, $"{LargeRange} must contain 1:99.");
+            Assert.That(LargeRange.Contains(1, 100), Is.True, $"{LargeRange} must contain 1:100.");
+            Assert.That(LargeRange.Contains(1, 150), Is.True, $"{LargeRange} must contain 1:150.");
+            Assert.That(LargeRange.Contains(100, 3), Is.True, $"{LargeRange} must contain 100:3.");
+            Assert.That(LargeRange.Contains(100, 99), Is.True, $"{LargeRange} must contain 100:99.");
+            Assert.That(LargeRange.Contains(100, 100), Is.False, $"{LargeRange} must not contain 100:100.");
+            Assert.That(LargeRange.Contains(100, 150), Is.False, $"{LargeRange} must not contain 100:150.");
 
-            Assert.IsTrue(LargeLineRange.Contains(0, 0));
-            Assert.IsTrue(LargeLineRange.Contains(0, 50));
-            Assert.IsTrue(LargeLineRange.Contains(1, 0));
-            Assert.IsTrue(LargeLineRange.Contains(1, 50));
-            Assert.IsTrue(LargeLineRange.Contains(300, 0));
-            Assert.IsTrue(LargeLineRange.Contains(300, 50));
-            Assert.IsFalse(LargeLineRange.Contains(301, 0));
-            Assert.IsFalse(LargeLineRange.Contains(301, 50));
+            Assert.That(LargeLineRange.Contains(0, 0), Is.True, $"{LargeLineRange} must contain 0:0.");
+            Assert.That(LargeLineRange.Contains(0, 50), Is.True, $"{LargeLineRange} must contain 0:50.");
+            Assert.That(LargeLineRange.Contains(1, 0), Is.True, $"{LargeLineRange} must contain 1:0.");
+            Assert.That(LargeLineRange.Contains(1, 50), Is.True, $"{LargeLineRange} must contain 1:50.");
+            Assert.That(LargeLineRange.Contains(300, 0), Is.True, $"{LargeLineRange} must contain 300:0.");
+            Assert.That(LargeLineRange.Contains(300, 50), Is.True, $"{LargeLineRange} must contain 300:50.");
+            Assert.That(LargeLineRange.Contains(301, 0), Is.False, $"{LargeLineRange} must not contain 301:0.");
+            Assert.That(LargeLineRange.Contains(301, 50), Is.False, $"{LargeLineRange} must not contain 301:50.");
         }
 
         [Test]
@@ -174,7 +178,7 @@ namespace SEE.DataModel.DG
         {
             foreach (Range range in AllRanges)
             {
-                Assert.IsTrue(range.Contains(range), $"Range {range} should contain itself.");
+                Assert.That(range.Contains(range), Is.True, $"Range {range} should contain itself.");
             }
         }
 
@@ -199,8 +203,8 @@ namespace SEE.DataModel.DG
             for (int i = 0; i < AllRanges.Count; i++)
             {
                 bool shouldContain = (containsBitmask & (1 << (AllRanges.Count - 1 - i))) != 0;
-                Assert.AreEqual(shouldContain, range.Contains(AllRanges[i]),
-                                $"Range {range} should {(shouldContain ? "" : "not ")}contain {AllRanges[i]}.");
+                Assert.That(range.Contains(AllRanges[i]), Is.EqualTo(shouldContain),
+                            $"Range {range} should {(shouldContain ? "" : "not ")}contain {AllRanges[i]}.");
             }
         }
     }

--- a/Assets/SEETests/TestRanges.cs
+++ b/Assets/SEETests/TestRanges.cs
@@ -93,8 +93,8 @@ namespace SEE.DataModel.DG
             Assert.That(OneFullLine.Contains(1, 10), Is.True, $"{OneFullLine} must contain 1:10.");
             Assert.That(OneFullLine.Contains(2, 0), Is.False, $"{OneFullLine} must not contain 2:0.");
 
-            Assert.That(OneFullLine.Contains(0, 0), Is.False, $"{OneFullLine} must not contain 0:0.");
-            Assert.That(OneFullLine.Contains(0, 5), Is.False, $"{OneFullLine} must not contain 0:5.");
+            Assert.That(TwoFullLines.Contains(0, 0), Is.False, $"{TwoFullLines} must not contain 0:0.");
+            Assert.That(TwoFullLines.Contains(0, 5), Is.False, $"{TwoFullLines} must not contain 0:5.");
             Assert.That(TwoFullLines.Contains(1, 0), Is.True, $"{TwoFullLines} must contain 1:0.");
             Assert.That(TwoFullLines.Contains(1, 1), Is.True, $"{TwoFullLines} must contain 1:1.");
             Assert.That(TwoFullLines.Contains(1, 10), Is.True, $"{TwoFullLines} must contain 1:10.");

--- a/Assets/SEETests/TestRectanglePacker.cs
+++ b/Assets/SEETests/TestRectanglePacker.cs
@@ -2,7 +2,6 @@
 using SEE.Layout.NodeLayouts;
 using SEE.Layout.NodeLayouts.RectanglePacking;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace SEE.Layout.RectanglePacking
@@ -12,36 +11,6 @@ namespace SEE.Layout.RectanglePacking
     /// </summary>
     internal class TestRectanglePacker
     {
-        /// <summary>
-        /// True if left and right are the same list (order is ignored).
-        /// </summary>
-        /// <param name="left">left list</param>
-        /// <param name="right">right list</param>
-        /// <returns>left and right have the very same elements</returns>
-        private static bool EqualLists(IList<PNode> left, IList<PNode> right)
-        {
-            // Note: the following condition does not deal with duplicates.
-            bool result = left.All(right.Contains) && left.Count == right.Count;
-            if (!result)
-            {
-                foreach (PNode node in left)
-                {
-                    if (!right.Contains(node))
-                    {
-                        Debug.LogErrorFormat("{0} contained in left, but not in right list.\n", node.ToString());
-                    }
-                }
-                foreach (PNode node in right)
-                {
-                    if (!left.Contains(node))
-                    {
-                        Debug.LogErrorFormat("{0} contained in right, but not in left list.\n", node.ToString());
-                    }
-                }
-            }
-            return result;
-        }
-
         /// <summary>
         /// Runs the example scenario used by Richard Wettel in his dissertation
         /// plus two additions at the end to check situations he did not cover
@@ -68,7 +37,7 @@ namespace SEE.Layout.RectanglePacking
             PNode El1 = B.Left;
             PNode D = B.Right;
 
-            Assert.AreSame(result, El1);
+            Assert.That(result, Is.SameAs(El1), "First split must return the node newly occupied by El1.");
 
             Assert.That(A.Occupied, Is.False);
             Assert.That(A.Rectangle.Position, Is.EqualTo(Vector2.zero));
@@ -90,7 +59,8 @@ namespace SEE.Layout.RectanglePacking
             Assert.That(D.Rectangle.Position, Is.EqualTo(new Vector2(8, 0)));
             Assert.That(D.Rectangle.Size, Is.EqualTo(new Vector2(6, 6)));
 
-            Assert.That(EqualLists(tree.FreeLeaves, new List<PNode>() { C, D }), Is.True);
+            Assert.That(tree.FreeLeaves, Is.EquivalentTo(new List<PNode>() { C, D }),
+                        "Free leaves after the first split.");
 
             // Second split
             result = tree.Split(C, new Vector2(7, 3));
@@ -99,7 +69,7 @@ namespace SEE.Layout.RectanglePacking
             PNode El2 = E.Left;
             PNode G = E.Right;
 
-            Assert.AreSame(result, El2);
+            Assert.That(result, Is.SameAs(El2), "Second split must return the node newly occupied by El2.");
 
             Assert.That(El2.Occupied, Is.True);
             Assert.That(El2.Rectangle.Position, Is.EqualTo(new Vector2(0, 6)));
@@ -117,7 +87,8 @@ namespace SEE.Layout.RectanglePacking
             Assert.That(F.Rectangle.Position, Is.EqualTo(new Vector2(0, 9)));
             Assert.That(F.Rectangle.Size, Is.EqualTo(new Vector2(14, 3)));
 
-            Assert.That(EqualLists(tree.FreeLeaves, new List<PNode>() { D, G, F }), Is.True);
+            Assert.That(tree.FreeLeaves, Is.EquivalentTo(new List<PNode>() { D, G, F }),
+                        "Free leaves after the second split.");
 
             // Third split
             // requested rectangle has same height as G
@@ -125,7 +96,7 @@ namespace SEE.Layout.RectanglePacking
             PNode El3 = G.Left;
             PNode H = G.Right;
 
-            Assert.AreSame(result, El3);
+            Assert.That(result, Is.SameAs(El3), "Third split must return the node newly occupied by El3.");
 
             Assert.That(El3.Occupied, Is.True);
             Assert.That(El3.Rectangle.Position, Is.EqualTo(G.Rectangle.Position));
@@ -135,7 +106,8 @@ namespace SEE.Layout.RectanglePacking
             Assert.That(H.Rectangle.Position, Is.EqualTo(G.Rectangle.Position + new Vector2(5, 0)));
             Assert.That(H.Rectangle.Size, Is.EqualTo(new Vector2(2, 3)));
 
-            Assert.That(EqualLists(tree.FreeLeaves, new List<PNode>() { D, H, F }), Is.True);
+            Assert.That(tree.FreeLeaves, Is.EquivalentTo(new List<PNode>() { D, H, F }),
+                        "Free leaves after the third split.");
 
             // Fourth split
             result = tree.Split(D, new Vector2(4, 4));
@@ -144,7 +116,7 @@ namespace SEE.Layout.RectanglePacking
             PNode El4 = I.Left;
             PNode K = I.Right;
 
-            Assert.AreSame(result, El4);
+            Assert.That(result, Is.SameAs(El4), "Fourth split must return the node newly occupied by El4.");
 
             Assert.That(El4.Occupied, Is.True);
             Assert.That(El4.Rectangle.Position, Is.EqualTo(D.Rectangle.Position));
@@ -162,19 +134,21 @@ namespace SEE.Layout.RectanglePacking
             Assert.That(K.Rectangle.Position, Is.EqualTo(D.Rectangle.Position + new Vector2(El4.Rectangle.Size.x, 0)));
             Assert.That(K.Rectangle.Size, Is.EqualTo(new Vector2(D.Rectangle.Size.x - El4.Rectangle.Size.x, El4.Rectangle.Size.y)));
 
-            Assert.That(EqualLists(tree.FreeLeaves, new List<PNode>() { J, K, H, F }), Is.True);
+            Assert.That(tree.FreeLeaves, Is.EquivalentTo(new List<PNode>() { J, K, H, F }),
+                        "Free leaves after the fourth split.");
 
             // Fifth split
             // perfect match
             result = tree.Split(J, J.Rectangle.Size);
 
-            Assert.AreSame(result, J);
+            Assert.That(result, Is.SameAs(J), "A perfectly matching split must return the node itself.");
 
             Assert.That(J.Occupied, Is.True);
             Assert.That(J.Left, Is.Null);
             Assert.That(J.Right, Is.Null);
 
-            Assert.That(EqualLists(tree.FreeLeaves, new List<PNode>() { K, H, F }), Is.True);
+            Assert.That(tree.FreeLeaves, Is.EquivalentTo(new List<PNode>() { K, H, F }),
+                        "Free leaves after the fifth split.");
 
             // Sixth split
             // requested rectangle has same width as F
@@ -182,7 +156,7 @@ namespace SEE.Layout.RectanglePacking
             PNode Fleft = F.Left;
             PNode Fright = F.Right;
 
-            Assert.AreSame(result, Fleft);
+            Assert.That(result, Is.SameAs(Fleft), "Sixth split must return the newly occupied left node of F.");
 
             Assert.That(Fleft.Occupied, Is.True);
             Assert.That(Fleft.Rectangle.Position, Is.EqualTo(F.Rectangle.Position));
@@ -192,7 +166,8 @@ namespace SEE.Layout.RectanglePacking
             Assert.That(Fright.Rectangle.Position, Is.EqualTo(F.Rectangle.Position + new Vector2(0, Fleft.Rectangle.Size.y)));
             Assert.That(Fright.Rectangle.Size, Is.EqualTo(new Vector2(F.Rectangle.Size.x, F.Rectangle.Size.y - Fleft.Rectangle.Size.y)));
 
-            Assert.That(EqualLists(tree.FreeLeaves, new List<PNode>() { K, H, Fright }), Is.True);
+            Assert.That(tree.FreeLeaves, Is.EquivalentTo(new List<PNode>() { K, H, Fright }),
+                        "Free leaves after the sixth split.");
         }
 
         /// <summary>

--- a/Assets/SEETests/TestReflexionAnalysis.cs
+++ b/Assets/SEETests/TestReflexionAnalysis.cs
@@ -18,7 +18,6 @@ namespace SEE.Tools.Architecture
     /// <summary>
     /// Shared code of unit tests for ReflexionAnalysis.
     /// </summary>
-    [Explicit("Reflexion tests currently don't work, tracked in #481")]
     internal class TestReflexionAnalysis : IObserver<ChangeEvent>
     {
         // TODO: Test types as well

--- a/Assets/SEETests/TestReflexionAnalysis.cs
+++ b/Assets/SEETests/TestReflexionAnalysis.cs
@@ -10,7 +10,6 @@ using SEE.Tools.ReflexionAnalysis;
 using SEE.Utils;
 using UnityEngine;
 using static SEE.Tools.ReflexionAnalysis.ReflexionGraph;
-using Assert = UnityEngine.Assertions.Assert;
 using Edge = SEE.DataModel.DG.Edge;
 
 namespace SEE.Tools.Architecture
@@ -23,7 +22,7 @@ namespace SEE.Tools.Architecture
         // TODO: Test types as well
         protected const string call = "call";
         protected ReflexionGraph graph;
-        protected SEELogger logger = new SEELogger();
+        protected SEELogger logger = new();
 
         /// <summary>
         /// The names of the edge types of hierarchical edges.
@@ -41,7 +40,7 @@ namespace SEE.Tools.Architecture
         /// </summary>
         protected static HashSet<string> HierarchicalEdgeTypes()
         {
-            HashSet<string> result = new HashSet<string>
+            HashSet<string> result = new()
             {
                 Enclosing,
                 "Belongs_To",
@@ -227,7 +226,8 @@ namespace SEE.Tools.Architecture
         /// <typeparam name="T">Type of events that should be counted</typeparam>
         protected void AssertEventCountEquals<T>(int expected, ChangeType? change = null, ReflexionSubgraphs? affectedGraph = null, bool ignoreVirtual = false, bool ignorePropagated = true) where T : ChangeEvent
         {
-            Assert.AreEqual(expected, changes.OfType<T>().Count(EventIncluded));
+            Assert.That(changes.OfType<T>().Count(EventIncluded), Is.EqualTo(expected),
+                        $"Unexpected number of {typeof(T).Name} events.");
 
             // Returns whether the given event shall be included in the count of events or not.
             // See method documentation for details.
@@ -322,8 +322,10 @@ namespace SEE.Tools.Architecture
             Edge result = new Edge(from, to, type);
             if (type == MapsToType)
             {
-                Assert.IsTrue(from.IsInImplementation());
-                Assert.IsTrue(to.IsInArchitecture());
+                Assert.That(from.IsInImplementation(), Is.True,
+                            $"Source {from.ID} of a {MapsToType} edge must be in the implementation.");
+                Assert.That(to.IsInArchitecture(), Is.True,
+                            $"Target {to.ID} of a {MapsToType} edge must be in the architecture.");
                 if (graph.AnalysisInitialized)
                 {
                     return graph.AddToMapping(from, to);
@@ -331,12 +333,14 @@ namespace SEE.Tools.Architecture
             }
             else if (from.IsInImplementation())
             {
-                Assert.IsTrue(to.IsInImplementation());
+                Assert.That(to.IsInImplementation(), Is.True,
+                            $"Target {to.ID} of an implementation edge must be in the implementation.");
                 result.SetInImplementation();
             }
             else if (from.IsInArchitecture())
             {
-                Assert.IsTrue(to.IsInArchitecture());
+                Assert.That(to.IsInArchitecture(), Is.True,
+                            $"Target {to.ID} of an architecture edge must be in the architecture.");
                 result.SetInArchitecture();
             }
 

--- a/Assets/SEETests/TestReflexionAnalysisStress.cs
+++ b/Assets/SEETests/TestReflexionAnalysisStress.cs
@@ -1,13 +1,13 @@
 ﻿using Cysharp.Threading.Tasks;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using SEE.DataModel.DG;
 using SEE.DataModel.DG.IO;
 using SEE.Tools.ReflexionAnalysis;
 using SEE.Utils;
-using UnityEngine;
 using SEE.Utils.Paths;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using UnityEngine;
 
 namespace SEE.Tools.Architecture
 {
@@ -90,7 +90,7 @@ namespace SEE.Tools.Architecture
         private async UniTask<Graph> LoadAsync(string path)
         {
             DataPath platformPath = new(Filenames.OnCurrentPlatform(path));
-            Debug.Log($"Loading graph from {platformPath.Path}...\n");;
+            Debug.Log($"Loading graph from {platformPath.Path}...\n");
             Graph result = await GraphReader.LoadAsync(platformPath, HierarchicalEdges, basePath: "", logger: logger);
             Assert.That(result, Is.Not.Null, $"No graph could be loaded from {platformPath.Path}.");
             Debug.Log($"Loaded {result.NodeCount} nodes and {result.EdgeCount} edges.\n");

--- a/Assets/SEETests/TestReflexionAnalysisStress.cs
+++ b/Assets/SEETests/TestReflexionAnalysisStress.cs
@@ -1,13 +1,13 @@
 ﻿using Cysharp.Threading.Tasks;
 using NUnit.Framework;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using UnityEngine;
 using SEE.DataModel.DG;
 using SEE.DataModel.DG.IO;
 using SEE.Tools.ReflexionAnalysis;
 using SEE.Utils;
 using SEE.Utils.Paths;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
-using UnityEngine;
 
 namespace SEE.Tools.Architecture
 {

--- a/Assets/SEETests/TestReflexionAnalysisStress.cs
+++ b/Assets/SEETests/TestReflexionAnalysisStress.cs
@@ -1,5 +1,5 @@
 ﻿using Cysharp.Threading.Tasks;
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SEE.DataModel.DG;
@@ -59,11 +59,13 @@ namespace SEE.Tools.Architecture
             foreach (Edge map in mapping.Edges())
             {
                 Node source = graph.GetNode(map.Source.ID);
-                Assert.IsTrue(source.IsInImplementation());
+                Assert.That(source, Is.Not.Null, $"Implementation node {map.Source.ID} not found.");
+                Assert.That(source.IsInImplementation(), Is.True,
+                            $"Node {map.Source.ID} is not in the implementation.");
                 Node target = graph.GetNode(map.Target.ID);
-                Assert.IsTrue(target.IsInArchitecture());
-                Assert.NotNull(source);
-                Assert.NotNull(target);
+                Assert.That(target, Is.Not.Null, $"Architecture node {map.Target.ID} not found.");
+                Assert.That(target.IsInArchitecture(), Is.True,
+                            $"Node {map.Target.ID} is not in the architecture.");
                 graph.AddToMapping(source, target);
             }
             p.End();
@@ -77,20 +79,20 @@ namespace SEE.Tools.Architecture
         {
             const string folderName = "minilax";
             await NonIncrementally(folderName);
-            int[] incrementally = graph.Summary();
+            int[] nonIncrementally = graph.Summary();
             Teardown();
             Setup();
             await Incrementally(folderName);
-            int[] nonIncrementally = graph.Summary();
-            Assert.AreEqual(incrementally, nonIncrementally);
+            int[] incrementally = graph.Summary();
+            Assert.That(incrementally, Is.EqualTo(nonIncrementally));
         }
 
         private async UniTask<Graph> LoadAsync(string path)
         {
-            DataPath platformPath =new(Filenames.OnCurrentPlatform(path));
+            DataPath platformPath = new(Filenames.OnCurrentPlatform(path));
             Debug.Log($"Loading graph from {platformPath.Path}...\n");;
             Graph result = await GraphReader.LoadAsync(platformPath, HierarchicalEdges, basePath: "", logger: logger);
-            Assert.That(result, !Is.Null);
+            Assert.That(result, Is.Not.Null, $"No graph could be loaded from {platformPath.Path}.");
             Debug.Log($"Loaded {result.NodeCount} nodes and {result.EdgeCount} edges.\n");
             //result.DumpTree();
             return result;

--- a/Assets/SEETests/TestReportGraphProvider/TestReportGraphProviderBase.cs
+++ b/Assets/SEETests/TestReportGraphProvider/TestReportGraphProviderBase.cs
@@ -210,10 +210,10 @@ namespace SEE.GraphProviders
         {
 
             ParsingConfig config = GetParsingConfig();
-            Assert.NotNull(config, "GetParsingConfig() returned null.");
+            Assert.That(config, Is.Not.Null, "GetParsingConfig() returned null.");
 
             IReportParser parser = config.CreateParser();
-            Assert.NotNull(parser, "CreateParser() returned null (IReportParser).");
+            Assert.That(parser, Is.Not.Null, "CreateParser() returned null (IReportParser).");
 
             return await parser.ParseAsync(fullReportPath);
         }
@@ -240,7 +240,7 @@ namespace SEE.GraphProviders
             foreach (KeyValuePair<string, Finding> expected in testFindings)
             {
                 Finding actual = FindActualNode(expected.Value);
-                Assert.NotNull(actual, $"Finding '{expected.Key}' not found.");
+                Assert.That(actual, Is.Not.Null, $"Finding '{expected.Key}' not found.");
                 AssertFindingMatch(actual, expected.Value);
             }
         }
@@ -287,8 +287,8 @@ namespace SEE.GraphProviders
         /// <param name="expected">Expected finding that defines the required values.</param>
         private void AssertFindingMatch(Finding actual, Finding expected)
         {
-            Assert.IsNotNull(actual);
-            Assert.IsNotNull(expected);
+            Assert.That(actual, Is.Not.Null, "The actual finding must not be null.");
+            Assert.That(expected, Is.Not.Null, "The expected finding must not be null.");
 
             if (!string.IsNullOrEmpty(expected.Context))
             {
@@ -343,39 +343,34 @@ namespace SEE.GraphProviders
         /// <param name="expectedMetrics">Expected metric key-value pairs.</param>
         private void AssertFindingMetricsMatch(Finding actual, Dictionary<string, string> expectedMetrics)
         {
-            Assert.NotNull(actual, "Finding is null.");
+            Assert.That(actual, Is.Not.Null, "Finding is null.");
 
             Dictionary<string, string> metrics = actual.Metrics;
 
-            Assert.NotNull(actual.Metrics, $"Metrics are null for node {actual.FullPath}.");
+            Assert.That(actual.Metrics, Is.Not.Null, $"Metrics are null for node {actual.FullPath}.");
 
             expectedMetrics ??= new Dictionary<string, string>();
 
             if (expectedMetrics.Count == 0)
             {
-                Assert.IsEmpty(
-                    actual.Metrics,
-                    $"Expected no metrics but found {actual.Metrics.Count} for {actual.FullPath}.");
+                Assert.That(actual.Metrics, Is.Empty,
+                            $"Expected no metrics but found {actual.Metrics.Count} for {actual.FullPath}.");
                 return;
             }
 
             foreach (KeyValuePair<string, string> testMetric in expectedMetrics)
             {
-                Assert.IsTrue(
-                    metrics.TryGetValue(testMetric.Key, out string actualValue),
-                    $"Missing metric '{testMetric.Key}'. Expected '{testMetric.Value}'.");
+                Assert.That(metrics.TryGetValue(testMetric.Key, out string actualValue), Is.True,
+                            $"Missing metric '{testMetric.Key}'. Expected '{testMetric.Value}'.");
 
-                Assert.AreEqual(
-                    testMetric.Value,
-                    actualValue,
-                    $"Metric '{testMetric.Key}' mismatch. Expected '{testMetric.Value}', got '{actualValue}'.");
+                Assert.That(actualValue, Is.EqualTo(testMetric.Value),
+                            $"Metric '{testMetric.Key}' mismatch.");
             }
 
             // Detect extra metrics that are present on the parsed finding but not expected by the test.
             List<string> unexpected = metrics.Keys.Except(expectedMetrics.Keys).ToList();
-            Assert.IsTrue(
-                unexpected.Count == 0,
-                $"Unexpected metric(s) present: {string.Join(", ", unexpected)}.");
+            Assert.That(unexpected, Is.Empty,
+                        $"Unexpected metric(s) present: {string.Join(", ", unexpected)}.");
         }
 
         /// <summary>
@@ -453,9 +448,9 @@ namespace SEE.GraphProviders
                     typeIndex.TryGetValue(fullIdentifier, out node);
                 }
 
-                Assert.NotNull(
-                    node,
-                    $"Node for path '{fullPath}' (Logical ID: {findingPathAsMainType}) not found in graph via Range or Type index.");
+                Assert.That(node, Is.Not.Null,
+                            $"Node for path '{fullPath}' (Logical ID: {findingPathAsMainType}) "
+                            + "not found in graph via Range or Type index.");
 
 
                 foreach (KeyValuePair<string, string> metricEntry in expected.Metrics)
@@ -476,10 +471,8 @@ namespace SEE.GraphProviders
                         return;
                     }
 
-                    Assert.AreEqual(
-                        metricEntry.Value,
-                        value,
-                        $"Metric '{metricKey}' mismatch in node '{node.ID}'. Expected '{metricEntry.Value}', got '{value}'.");
+                    Assert.That(value, Is.EqualTo(metricEntry.Value),
+                                $"Metric '{metricKey}' mismatch in node '{node.ID}'.");
                 }
             }
         }

--- a/Assets/SEETests/TestSEEDate.cs
+++ b/Assets/SEETests/TestSEEDate.cs
@@ -16,7 +16,7 @@ namespace SEE.Utils
         [Test]
         public void TestToDate()
         {
-            Assert.AreEqual(new DateTime(2023, 2, 28), SEEDate.ToDate(aDate));
+            Assert.That(SEEDate.ToDate(aDate), Is.EqualTo(new DateTime(2023, 2, 28)));
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace SEE.Utils
         [Test]
         public void TestInvalidDate()
         {
-            Assert.Throws<ArgumentException>(() => SEEDate.ToDate("2023-10-01"));
+            Assert.That(() => SEEDate.ToDate("2023-10-01"), Throws.TypeOf<ArgumentException>());
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace SEE.Utils
         [Test]
         public void TestImpossibleDate1()
         {
-            Assert.Throws<ArgumentException>(() => SEEDate.ToDate("2023/02/29"));
+            Assert.That(() => SEEDate.ToDate("2023/02/29"), Throws.TypeOf<ArgumentException>());
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace SEE.Utils
         [Test]
         public void TestImpossibleDate2()
         {
-            Assert.Throws<ArgumentException>(() => SEEDate.ToDate("2023/04/31"));
+            Assert.That(() => SEEDate.ToDate("2023/04/31"), Throws.TypeOf<ArgumentException>());
         }
     }
 }

--- a/Assets/SEETests/TestSortedRanges.cs
+++ b/Assets/SEETests/TestSortedRanges.cs
@@ -15,8 +15,9 @@ namespace SEE.DataModel.DG.SourceRange
         public void TestNone()
         {
             SortedRanges sr = new();
-            Assert.AreEqual(0, sr.Count);
-            Assert.IsFalse(sr.TryGetValue(1, out GraphIndex.SourceRange _));
+            Assert.That(sr.Count, Is.EqualTo(0));
+            Assert.That(sr.TryGetValue(1, out GraphIndex.SourceRange _), Is.False,
+                        "There must be no range containing line 1.");
         }
 
         [Test]
@@ -25,7 +26,7 @@ namespace SEE.DataModel.DG.SourceRange
             SortedRanges sr = new();
             GraphIndex.SourceRange r1 = new(2, 4, new Node());
             sr.Add(r1);
-            Assert.AreEqual(1, sr.Count);
+            Assert.That(sr.Count, Is.EqualTo(1));
 
             AssertContained(sr, r1);
         }
@@ -66,7 +67,7 @@ namespace SEE.DataModel.DG.SourceRange
                 sr.Add(r);
             }
 
-            Assert.AreEqual(ranges.Count, sr.Count);
+            Assert.That(sr.Count, Is.EqualTo(ranges.Count));
 
             foreach (GraphIndex.SourceRange r in ranges)
             {
@@ -76,15 +77,18 @@ namespace SEE.DataModel.DG.SourceRange
 
         private static void AssertContained(SortedRanges sr, GraphIndex.SourceRange expected)
         {
-            Assert.IsFalse(sr.TryGetValue(expected.Range.StartLine - 1, out GraphIndex.SourceRange _));
+            Assert.That(sr.TryGetValue(expected.Range.StartLine - 1, out GraphIndex.SourceRange _), Is.False,
+                        $"No range may contain line {expected.Range.StartLine - 1}.");
             {
                 for (int l = expected.Range.StartLine; l < expected.Range.EndLine; l++)
                 {
-                    Assert.IsTrue(sr.TryGetValue(l, out GraphIndex.SourceRange actual));
-                    Assert.AreSame(expected, actual);
+                    Assert.That(sr.TryGetValue(l, out GraphIndex.SourceRange actual), Is.True,
+                                $"There is no range containing line {l}.");
+                    Assert.That(actual, Is.SameAs(expected), $"Wrong range found for line {l}.");
                 }
             }
-            Assert.IsFalse(sr.TryGetValue(expected.Range.EndLine, out GraphIndex.SourceRange _));
+            Assert.That(sr.TryGetValue(expected.Range.EndLine, out GraphIndex.SourceRange _), Is.False,
+                        $"No range may contain line {expected.Range.EndLine}.");
         }
 
         [Test]
@@ -124,13 +128,14 @@ namespace SEE.DataModel.DG.SourceRange
         {
             SortedRanges sr = new();
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                foreach (GraphIndex.SourceRange r in ranges)
-                {
-                    sr.Add(r);
-                }
-            });
+            Assert.That(() =>
+                        {
+                            foreach (GraphIndex.SourceRange r in ranges)
+                            {
+                                sr.Add(r);
+                            }
+                        },
+                        Throws.TypeOf<ArgumentException>());
         }
     }
 }

--- a/Assets/SEETests/TestSourceRangeIndex.cs
+++ b/Assets/SEETests/TestSourceRangeIndex.cs
@@ -22,10 +22,10 @@ namespace SEE.DataModel.DG.SourceRange
         public void TestConsistent1()
         {
             SourceRangeIndex index = GetIndexByPath(g);
-            Assert.IsTrue(index.IsIsomorphic());
+            Assert.That(index.IsIsomorphic(), Is.True, "The index must be isomorphic to the graph.");
             // 11 nodes were added to the graph, but 2 are ignored because of an
             // empty path.
-            Assert.AreEqual(9, index.Count);
+            Assert.That(index.Count, Is.EqualTo(9));
 
             AssertNotFound(index, c1, 1);
             AssertNotFound(index, c1, 49);
@@ -86,7 +86,7 @@ namespace SEE.DataModel.DG.SourceRange
             Node c1m1M4 = Child(g, c1m1, "c1.m1.M4", type: "Method", directory: "mydir/", filename: "myfile.java", line: 54, length: 1);
 
             SourceRangeIndex index = GetIndexByPath(g);
-            Assert.IsTrue(index.IsIsomorphic());
+            Assert.That(index.IsIsomorphic(), Is.True, "The index must be isomorphic to the graph.");
             AssertFound(index, c1m1M4, 54);
         }
 
@@ -100,14 +100,17 @@ namespace SEE.DataModel.DG.SourceRange
         /// <param name="line">source line where to search</param>
         private static void AssertNotFound(SourceRangeIndex index, Node unexpected, int line)
         {
-            Assert.IsTrue(!index.TryGetValue(unexpected.Path(), line, out Node node) // no node found at all
-                || (node != null && unexpected != node)); // if one is found, it must be different from unexpected
+            Assert.That(!index.TryGetValue(unexpected.Path(), line, out Node node) // no node found at all
+                        || (node != null && unexpected != node), // if one is found, it must differ
+                        Is.True,
+                        $"{unexpected.ID} must not be found at line {line}.");
         }
 
         private static void AssertFound(SourceRangeIndex index, Node expected, int line)
         {
-            Assert.IsTrue(index.TryGetValue(expected.Path(), line, out Node found));
-            Assert.AreEqual(expected, found);
+            Assert.That(index.TryGetValue(expected.Path(), line, out Node found), Is.True,
+                        $"There is no node at line {line} in {expected.Path()}.");
+            Assert.That(found, Is.EqualTo(expected));
         }
 
         [Test]
@@ -117,7 +120,7 @@ namespace SEE.DataModel.DG.SourceRange
             Child(g, c1m1, "c1.m1.M4", type: "Method", directory: "mydir/", filename: "myfile.java", line: 56, length: 1);
 
             SourceRangeIndex index = GetIndexByPath(g);
-            Assert.IsFalse(index.IsIsomorphic());
+            Assert.That(index.IsIsomorphic(), Is.False, "The index must not be isomorphic to the graph.");
 
             LogAssert.Expect(LogType.Error, new Regex("Range c1.m1.M4.* is subsumed by c1.m1.M3.M1.*"));
         }
@@ -129,7 +132,7 @@ namespace SEE.DataModel.DG.SourceRange
             Child(g, c1m1, "c1.m1.M4", type: "Method", directory: "mydir/", filename: "myfile.java", line: 53, length: 1);
 
             SourceRangeIndex index = GetIndexByPath(g);
-            Assert.IsFalse(index.IsIsomorphic());
+            Assert.That(index.IsIsomorphic(), Is.False, "The index must not be isomorphic to the graph.");
 
             LogAssert.Expect(LogType.Error, new Regex("Range .* is subsumed by .*"));
         }
@@ -143,7 +146,8 @@ namespace SEE.DataModel.DG.SourceRange
             // thrown.
             Child(g, c1m1, "c1.m1.M4", type: "Method", directory: "mydir/", filename: "myfile.java", line: 54, length: 3);
 
-            Assert.Throws<ArgumentException>(() =>  new SourceRangeIndex(g, node => node.Path()));
+            Assert.That(() => new SourceRangeIndex(g, node => node.Path()),
+                        Throws.TypeOf<ArgumentException>());
         }
 
         private Graph g;
@@ -215,7 +219,7 @@ namespace SEE.DataModel.DG.SourceRange
             NewNode(g, "c3", type: "Class", directory: "mydir/", filename: "myfile.java", line: 50, length: 30);
 
             SourceRangeIndex index = GetIndexByPath(g);
-            Assert.IsFalse(index.IsIsomorphic());
+            Assert.That(index.IsIsomorphic(), Is.False, "The index must not be isomorphic to the graph.");
 
             LogAssert.Expect(LogType.Error, new Regex("Range c2.* is subsumed by c1.*"));
             LogAssert.Expect(LogType.Error, new Regex("Range c3.* is subsumed by c2.*"));

--- a/Assets/SEETests/TestStringListSerializer.cs
+++ b/Assets/SEETests/TestStringListSerializer.cs
@@ -6,7 +6,7 @@ namespace SEE.Utils
     /// <summary>
     /// Test cases for <see cref="StringListSerializer"/>.
     /// </summary>
-    class TestStringListSerializer
+    internal class TestStringListSerializer
     {
         [Test]
         public void TestMultipleElements()
@@ -29,7 +29,8 @@ namespace SEE.Utils
         [Test]
         public void TestNullElements()
         {
-            Assert.Throws<System.ArgumentNullException>(() => StringListSerializer.Serialize(new List<string>() { null, null }));
+            Assert.That(() => StringListSerializer.Serialize(new List<string>() { null, null }),
+                        Throws.ArgumentNullException);
         }
 
         [Test]
@@ -41,14 +42,15 @@ namespace SEE.Utils
         [Test]
         public void TestNull()
         {
-            Assert.Throws<System.ArgumentNullException>(() => StringListSerializer.Serialize(null));
+            Assert.That(() => StringListSerializer.Serialize(null), Throws.ArgumentNullException);
         }
 
         private static void Check(List<string> stringList)
         {
             string serialized = StringListSerializer.Serialize(stringList);
             List<string> unserialized = StringListSerializer.Unserialize(serialized);
-            Assert.AreEqual(stringList, unserialized);
+            Assert.That(unserialized, Is.EqualTo(stringList),
+                        "Unserializing a serialized list must yield the original list.");
         }
     }
 }

--- a/Assets/SEETests/TestThreadSafeHashSet.cs
+++ b/Assets/SEETests/TestThreadSafeHashSet.cs
@@ -16,14 +16,14 @@ namespace SEE.Utils
         public void TestAdd()
         {
             ThreadSafeHashSet<int> set = new();
-            Assert.That(set.Add(1));
-            Assert.That(set.Add(2));
-            Assert.That(!set.Add(1));
-            Assert.That(!set.Add(2));
+            Assert.That(set.Add(1), Is.True, "1 was not yet contained.");
+            Assert.That(set.Add(2), Is.True, "2 was not yet contained.");
+            Assert.That(set.Add(1), Is.False, "1 was already contained.");
+            Assert.That(set.Add(2), Is.False, "2 was already contained.");
 
             foreach (int i in set)
             {
-                Assert.That(i == 1 || i == 2);
+                Assert.That(i, Is.EqualTo(1).Or.EqualTo(2));
             }
         }
 
@@ -41,7 +41,7 @@ namespace SEE.Utils
             t2.Start();
             t1.Join();
             t2.Join();
-            Assert.AreEqual(total, set.Count);
+            Assert.That(set.Count, Is.EqualTo(total));
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace SEE.Utils
             a2.Join();
             a1.Join();
 
-            Assert.AreEqual(total, set.Count);
+            Assert.That(set.Count, Is.EqualTo(total));
         }
     }
 

--- a/Assets/SEETests/TestTokenMetrics.cs
+++ b/Assets/SEETests/TestTokenMetrics.cs
@@ -46,7 +46,7 @@ namespace SEE.Scanner
         {
             IEnumerable<AntlrToken> tokens = AntlrToken.FromString(code, AntlrLanguage.CSharp);
             TokenMetrics.Gather(tokens, out _, out _, out int complexity, out _);
-            Assert.AreEqual(expected, complexity);
+            Assert.That(complexity, Is.EqualTo(expected));
         }
 
         private const float tolerance = 0.001f; // Tolerance for float value comparisons.
@@ -75,7 +75,7 @@ namespace SEE.Scanner
                                                         NumberOfDeliveredBugs: 0f);
 
             TokenMetrics.Gather(tokens, out _, out _, out _, out TokenMetrics.HalsteadMetrics halstead);
-            Assert.AreEqual(expected, halstead);
+            Assert.That(halstead, Is.EqualTo(expected));
         }
 
         [Test]
@@ -106,18 +106,18 @@ namespace SEE.Scanner
                                                         NumberOfDeliveredBugs: 0.05547369f);
             TokenMetrics.Gather(tokens, out _, out _, out _, out TokenMetrics.HalsteadMetrics halstead);
 
-            Assert.AreEqual(expected.DistinctOperators, halstead.DistinctOperators);
-            Assert.AreEqual(expected.DistinctOperands, halstead.DistinctOperands);
-            Assert.AreEqual(expected.TotalOperators, halstead.TotalOperators);
-            Assert.AreEqual(expected.TotalOperands, halstead.TotalOperands);
-            Assert.AreEqual(expected.ProgramVocabulary, halstead.ProgramVocabulary);
-            Assert.AreEqual(expected.ProgramLength, halstead.ProgramLength);
-            Assert.AreEqual(expected.EstimatedProgramLength, halstead.EstimatedProgramLength, tolerance);
-            Assert.AreEqual(expected.Volume, halstead.Volume, tolerance);
-            Assert.AreEqual(expected.Difficulty, halstead.Difficulty, tolerance);
-            Assert.AreEqual(expected.Effort, halstead.Effort, tolerance);
-            Assert.AreEqual(expected.TimeRequiredToProgram, halstead.TimeRequiredToProgram, tolerance);
-            Assert.AreEqual(expected.NumberOfDeliveredBugs, halstead.NumberOfDeliveredBugs, tolerance);
+            Assert.That(halstead.DistinctOperators, Is.EqualTo(expected.DistinctOperators));
+            Assert.That(halstead.DistinctOperands, Is.EqualTo(expected.DistinctOperands));
+            Assert.That(halstead.TotalOperators, Is.EqualTo(expected.TotalOperators));
+            Assert.That(halstead.TotalOperands, Is.EqualTo(expected.TotalOperands));
+            Assert.That(halstead.ProgramVocabulary, Is.EqualTo(expected.ProgramVocabulary));
+            Assert.That(halstead.ProgramLength, Is.EqualTo(expected.ProgramLength));
+            Assert.That(halstead.EstimatedProgramLength, Is.EqualTo(expected.EstimatedProgramLength).Within(tolerance));
+            Assert.That(halstead.Volume, Is.EqualTo(expected.Volume).Within(tolerance));
+            Assert.That(halstead.Difficulty, Is.EqualTo(expected.Difficulty).Within(tolerance));
+            Assert.That(halstead.Effort, Is.EqualTo(expected.Effort).Within(tolerance));
+            Assert.That(halstead.TimeRequiredToProgram, Is.EqualTo(expected.TimeRequiredToProgram).Within(tolerance));
+            Assert.That(halstead.NumberOfDeliveredBugs, Is.EqualTo(expected.NumberOfDeliveredBugs).Within(tolerance));
         }
 
         [Test]
@@ -142,18 +142,18 @@ namespace SEE.Scanner
                                                         NumberOfDeliveredBugs: 0.0121804f);
             TokenMetrics.Gather(tokens, out _, out _, out _, out TokenMetrics.HalsteadMetrics halstead);
 
-            Assert.AreEqual(expected.DistinctOperators, halstead.DistinctOperators);
-            Assert.AreEqual(expected.DistinctOperands, halstead.DistinctOperands);
-            Assert.AreEqual(expected.TotalOperators, halstead.TotalOperators);
-            Assert.AreEqual(expected.TotalOperands, halstead.TotalOperands);
-            Assert.AreEqual(expected.ProgramVocabulary, halstead.ProgramVocabulary);
-            Assert.AreEqual(expected.ProgramLength, halstead.ProgramLength);
-            Assert.AreEqual(expected.EstimatedProgramLength, halstead.EstimatedProgramLength, tolerance);
-            Assert.AreEqual(expected.Volume, halstead.Volume, tolerance);
-            Assert.AreEqual(expected.Difficulty, halstead.Difficulty, tolerance);
-            Assert.AreEqual(expected.Effort, halstead.Effort, tolerance);
-            Assert.AreEqual(expected.TimeRequiredToProgram, halstead.TimeRequiredToProgram, tolerance);
-            Assert.AreEqual(expected.NumberOfDeliveredBugs, halstead.NumberOfDeliveredBugs, tolerance);
+            Assert.That(halstead.DistinctOperators, Is.EqualTo(expected.DistinctOperators));
+            Assert.That(halstead.DistinctOperands, Is.EqualTo(expected.DistinctOperands));
+            Assert.That(halstead.TotalOperators, Is.EqualTo(expected.TotalOperators));
+            Assert.That(halstead.TotalOperands, Is.EqualTo(expected.TotalOperands));
+            Assert.That(halstead.ProgramVocabulary, Is.EqualTo(expected.ProgramVocabulary));
+            Assert.That(halstead.ProgramLength, Is.EqualTo(expected.ProgramLength));
+            Assert.That(halstead.EstimatedProgramLength, Is.EqualTo(expected.EstimatedProgramLength).Within(tolerance));
+            Assert.That(halstead.Volume, Is.EqualTo(expected.Volume).Within(tolerance));
+            Assert.That(halstead.Difficulty, Is.EqualTo(expected.Difficulty).Within(tolerance));
+            Assert.That(halstead.Effort, Is.EqualTo(expected.Effort).Within(tolerance));
+            Assert.That(halstead.TimeRequiredToProgram, Is.EqualTo(expected.TimeRequiredToProgram).Within(tolerance));
+            Assert.That(halstead.NumberOfDeliveredBugs, Is.EqualTo(expected.NumberOfDeliveredBugs).Within(tolerance));
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace SEE.Scanner
         {
             IEnumerable<AntlrToken> tokens = AntlrToken.FromString(code, AntlrLanguage.CPP);
             TokenMetrics.Gather(tokens, out TokenMetrics.LineMetrics lineMetrics, out _, out _, out _);
-            Assert.AreEqual(expected, lineMetrics.LOC);
+            Assert.That(lineMetrics.LOC, Is.EqualTo(expected));
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace SEE.Scanner
         {
             IEnumerable<AntlrToken> tokens = AntlrToken.FromString(code, AntlrLanguage.CPP);
             TokenMetrics.Gather(tokens, out TokenMetrics.LineMetrics lineMetrics, out _, out _, out _);
-            Assert.AreEqual(expected, lineMetrics.Comments);
+            Assert.That(lineMetrics.Comments, Is.EqualTo(expected));
         }
 
     }

--- a/Assets/SEETests/TestUnionFind.cs
+++ b/Assets/SEETests/TestUnionFind.cs
@@ -19,23 +19,28 @@ namespace SEE.Utils
             // Initially, each element is its own parent
             foreach (string el in elements)
             {
-                Assert.AreEqual(el, uf.Find(el));
+                Assert.That(uf.Find(el), Is.EqualTo(el),
+                            $"{el} must initially be its own representative.");
             }
             // Union elements with the same length
             uf.PartitionByValue();
 
             // Now a, b, c, d, e should be in the same set
             string root = uf.Find("a");
-            Assert.AreEqual(root, uf.Find("b"));
-            Assert.AreEqual(root, uf.Find("c"));
-            Assert.AreEqual(root, uf.Find("d"));
-            Assert.AreEqual(root, uf.Find("e"));
-            Assert.AreEqual(uf.Find("ff"), uf.Find("ee"));
+            Assert.That(uf.Find("b"), Is.EqualTo(root), "b must be in the same set as a.");
+            Assert.That(uf.Find("c"), Is.EqualTo(root), "c must be in the same set as a.");
+            Assert.That(uf.Find("d"), Is.EqualTo(root), "d must be in the same set as a.");
+            Assert.That(uf.Find("e"), Is.EqualTo(root), "e must be in the same set as a.");
+            Assert.That(uf.Find("ee"), Is.EqualTo(uf.Find("ff")),
+                        "ee must be in the same set as ff.");
 
             // Strings with different lengths should be in different sets.
-            Assert.AreNotEqual(uf.Find("ggg"), uf.Find("ee"));
-            Assert.AreNotEqual(uf.Find("ggg"), uf.Find("a"));
-            Assert.AreNotEqual(uf.Find("ff"), uf.Find("a"));
+            Assert.That(uf.Find("ee"), Is.Not.EqualTo(uf.Find("ggg")),
+                        "ee and ggg must be in different sets.");
+            Assert.That(uf.Find("a"), Is.Not.EqualTo(uf.Find("ggg")),
+                        "a and ggg must be in different sets.");
+            Assert.That(uf.Find("a"), Is.Not.EqualTo(uf.Find("ff")),
+                        "a and ff must be in different sets.");
         }
 
         [Test]
@@ -45,7 +50,7 @@ namespace SEE.Utils
             string[] elements = new[] { "a", "b" };
             UnionFind<string, int> uf = new(elements, s => s.Length);
             // "c" was not part of the initial set.
-            Assert.Throws<System.ArgumentException>(() => uf.Union("a", "c"));
+            Assert.That(() => uf.Union("a", "c"), Throws.TypeOf<System.ArgumentException>());
         }
     }
 }

--- a/Assets/SEETests/TestUnionFind.cs
+++ b/Assets/SEETests/TestUnionFind.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using UnityEngine.TestTools;
 
 namespace SEE.Utils
 {
@@ -51,6 +50,17 @@ namespace SEE.Utils
             UnionFind<string, int> uf = new(elements, s => s.Length);
             // "c" was not part of the initial set.
             Assert.That(() => uf.Union("a", "c"), Throws.TypeOf<System.ArgumentException>());
+        }
+
+        [Test]
+        public void TestFind()
+        {
+            UnionFind<int, int> unionFind = new(new[] { 1, 2, 3 }, i => i);
+            unionFind.Union(1, 2);
+
+            int root = unionFind.Find(1);
+            Assert.That(unionFind.Find(2), Is.EqualTo(root), "2 must be in the same set as 1.");
+            Assert.That(unionFind.Find(3), Is.Not.EqualTo(root), "3 must be in a different set than 1.");
         }
     }
 }

--- a/Assets/SEETests/UI/TestMenuEntry.cs
+++ b/Assets/SEETests/UI/TestMenuEntry.cs
@@ -53,6 +53,7 @@ namespace SEE.UI.Menu
             Assert.That(entry.Enabled, Is.True);
             Assert.That(entry.Icon, Is.EqualTo(' '));
             Assert.That(entry.EntryColor, Is.EqualTo(default(Color)));
+            Assert.That(entry.DisabledColor, Is.Not.EqualTo(default(Color)), "Entry color must differ from disabled color!");
             Assert.That(testItems.Count, Is.EqualTo(0), "DoAction() may not be called during initialization!");
             entry.SelectAction();
             Assert.That(testItems.Count, Is.EqualTo(1), "DoAction() must call the given UnityAction!");

--- a/Assets/SEETests/UI/TestMenuEntry.cs
+++ b/Assets/SEETests/UI/TestMenuEntry.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Events;
 
 namespace SEE.UI.Menu
 {
@@ -49,18 +48,14 @@ namespace SEE.UI.Menu
             List<int> testItems = new();
             void Action() => testItems.Add(1);
             MenuEntry entry = CreateMenuEntry(Action, "Test");
-            Assert.AreEqual(null, entry.Description);
-            Assert.AreEqual("Test", entry.Title);
-            Assert.AreEqual(true, entry.Enabled);
-            Assert.AreEqual(' ', entry.Icon);
-            Assert.AreEqual(default(Color), entry.EntryColor);
-#if INCLUDE_STEAM_VR
-
-            Assert.AreNotEqual(default(Color), entry.DisabledColor, "Entry color must differ from disabled color!");
-#endif
-            Assert.AreEqual(0, testItems.Count, "DoAction() may not be called during initialization!");
+            Assert.That(entry.Description, Is.Null);
+            Assert.That(entry.Title, Is.EqualTo("Test"));
+            Assert.That(entry.Enabled, Is.True);
+            Assert.That(entry.Icon, Is.EqualTo(' '));
+            Assert.That(entry.EntryColor, Is.EqualTo(default(Color)));
+            Assert.That(testItems.Count, Is.EqualTo(0), "DoAction() may not be called during initialization!");
             entry.SelectAction();
-            Assert.AreEqual(1, testItems.Count, "DoAction() must call the given UnityAction!");
+            Assert.That(testItems.Count, Is.EqualTo(1), "DoAction() must call the given UnityAction!");
         }
 
         [Test, TestCaseSource(nameof(ValidConstructorSupplier))]
@@ -71,23 +66,18 @@ namespace SEE.UI.Menu
             // Given action must either be null or NOP for this test
             if (action == null)
             {
-                Assert.IsNull(entry.SelectAction);
+                Assert.That(entry.SelectAction, Is.Null);
             }
             else
             {
-                Assert.DoesNotThrow(() => entry.SelectAction());
+                Assert.That(() => entry.SelectAction(), Throws.Nothing);
             }
 
-            Assert.AreEqual(description, entry.Description);
-            Assert.AreEqual(title, entry.Title);
-            Assert.AreEqual(enabled, entry.Enabled);
-            Assert.AreEqual(icon, entry.Icon);
-            Assert.AreEqual(entryColor, entry.EntryColor);
-#if INCLUDE_STEAM_VR
-
-            Debug.Log($"{entryColor}, {entry.DisabledColor}");
-            Assert.AreNotEqual(entryColor, entry.DisabledColor, "Disabled color must differ from normal color!");
-#endif
+            Assert.That(entry.Description, Is.EqualTo(description));
+            Assert.That(entry.Title, Is.EqualTo(title));
+            Assert.That(entry.Enabled, Is.EqualTo(enabled));
+            Assert.That(entry.Icon, Is.EqualTo(icon));
+            Assert.That(entry.EntryColor, Is.EqualTo(entryColor));
         }
     }
 }

--- a/Assets/SEETests/UI/TestToggleMenuEntry.cs
+++ b/Assets/SEETests/UI/TestToggleMenuEntry.cs
@@ -25,8 +25,8 @@ namespace SEE.UI.Menu
         {
             MenuEntry entry1 = new(() => {}, "Test");
             MenuEntry entry2 = new(() => {}, "Test");
-            Assert.DoesNotThrow(() => entry1.SelectAction());
-            Assert.DoesNotThrow(() => entry2.SelectAction());
+            Assert.That(() => entry1.SelectAction(), Throws.Nothing);
+            Assert.That(() => entry2.SelectAction(), Throws.Nothing);
         }
 
         [Test]
@@ -40,20 +40,23 @@ namespace SEE.UI.Menu
             void ExitAction() => testItems.Add(true);
             MenuEntry entry = new(() => {}, "Test", ExitAction);
             selectionMenu.AddEntry(entry);
-            Assert.AreNotEqual(entry, selectionMenu.ActiveEntry, "SelectionMenu.ActiveEntry isn't set correctly!");
-            Assert.AreEqual(0, testItems.Count, "Entry/ExitAction may not be called during initialization!");
+            Assert.That(selectionMenu.ActiveEntry, Is.Not.EqualTo(entry),
+                        "SelectionMenu.ActiveEntry isn't set correctly!");
+            Assert.That(testItems.Count, Is.EqualTo(0), "Entry/ExitAction may not be called during initialization!");
             selectionMenu.ActiveEntry = entry;
-            Assert.AreEqual(entry, selectionMenu.ActiveEntry, "SelectionMenu.ActiveEntry isn't set correctly.");
-            Assert.AreEqual(0, testItems.Count, "ExitAction isn't called correctly!");
+            Assert.That(selectionMenu.ActiveEntry, Is.EqualTo(entry), "SelectionMenu.ActiveEntry isn't set correctly.");
+            Assert.That(testItems.Count, Is.EqualTo(0), "ExitAction isn't called correctly!");
             selectionMenu.ActiveEntry = null;
-            Assert.AreNotEqual(entry, selectionMenu.ActiveEntry, "SelectionMenu.ActiveEntry isn't set correctly!");
-            Assert.AreEqual(1, testItems.Count, "ExitAction isn't called correctly!");
+            Assert.That(selectionMenu.ActiveEntry, Is.Not.EqualTo(entry),
+                        "SelectionMenu.ActiveEntry isn't set correctly!");
+            Assert.That(testItems.Count, Is.EqualTo(1), "ExitAction isn't called correctly!");
             selectionMenu.ActiveEntry = entry;
-            Assert.AreEqual(entry, selectionMenu.ActiveEntry, "SelectionMenu.ActiveEntry isn't set correctly!");
-            Assert.AreEqual(1, testItems.Count, "ExitAction isn't called correctly!");
+            Assert.That(selectionMenu.ActiveEntry, Is.EqualTo(entry), "SelectionMenu.ActiveEntry isn't set correctly!");
+            Assert.That(testItems.Count, Is.EqualTo(1), "ExitAction isn't called correctly!");
             selectionMenu.ActiveEntry = null;
-            Assert.AreNotEqual(entry, selectionMenu.ActiveEntry, "SelectionMenu.ActiveEntry isn't set correctly!");
-            Assert.AreEqual(2, testItems.Count, "ExitAction isn't called correctly!");
+            Assert.That(selectionMenu.ActiveEntry, Is.Not.EqualTo(entry),
+                        "SelectionMenu.ActiveEntry isn't set correctly!");
+            Assert.That(testItems.Count, Is.EqualTo(2), "ExitAction isn't called correctly!");
             Destroyer.Destroy(go);
         }
     }


### PR DESCRIPTION
Closes #981.

Migrates the whole test suite from NUnit's classic assertion model
(`Assert.AreEqual`, `Assert.IsTrue`, …) to the constraint model
(`Assert.That(actual, Is.…)`), covering 52 files in `Assets/SEETests` and
`Assets/SEEPlayModeTests`: roughly 940 classic assertions plus 187 calls that
passed a bare boolean to `Assert.That` and therefore reported nothing but a line
number when they failed.

Both properties are now enforceable by inspection: neither assembly contains a
classic assertion, a `CollectionAssert`/`StringAssert` call, or an `Assert.That`
without a constraint.

## Approach

The migration is not purely mechanical. Applied throughout:

- The purpose-built constraint is preferred over a literal translation:
  `Is.Empty` instead of `AreEqual(0, x.Count)`, `Is.EquivalentTo` for sets,
  `Does.Exist` for files and directories, `Has.Member`, `Does.StartWith`,
  `Is.InstanceOf<T>`, `Is.Null`.
- `Assert.AreSame` becomes `Is.SameAs`, never `Is.EqualTo`, so reference
  identity stays reference identity.
- `Assert.Throws<T>` becomes `Throws.TypeOf<T>()` rather than
  `Throws.InstanceOf<T>()`, which would also accept subclasses.
- Genuine predicates keep `Is.True`/`Is.False` but gain a hand-written message,
  because the constraint alone reports no more than the classic form did.
- The argument order of every `Assert.AreEqual` was checked individually. Five
  files passed the actual value first, so a mechanical rewrite would have
  swapped expected and actual in the failure report.

## Defects found and fixed along the way

- **`CityCursor` could claim another city's elements.** It decided whether a
  hovered element belongs to this city with `selectedGraph.Equals(city.LoadedGraph)`.
  `Graph.Equals` is value based, so two cities showing two equal but distinct
  graphs both took hover focus. Now compared with `==`, i.e. by identity.
- **`TestReflexionAnalysis` was asserting with Unity's assertions**, not NUnit's:
  the file aliased `Assert` to `UnityEngine.Assertions.Assert`. A violated Unity
  assertion throws `AssertionException`, which NUnit reports as an error rather
  than a failure, and those assertions are conditional on `UNITY_ASSERTIONS` and
  would be compiled away where that symbol is undefined. This affected the three
  derived reflexion fixtures, which call `AssertEventCountEquals`.
- **A missing null check** in `TestJacocoImporter.AddMetricToMethodNode`.
- **A copy-paste error** in `TestPropertyDialog`, which re-checked the game
  object instead of the selector.
- **A message that enumerated a Git query twice** in `TestGitSEE`, on every call
  including passing ones, because the interpolated string was built eagerly.
- Smaller items: a stray UTF-8 BOM in `AddEdgeAction.cs`, two malformed doc
  comments, unused imports, dead code (`SceneQueries.GetGraphs`,
  `SceneQueries.GetRoots`, `GameNodeHierarchy.Check`).

## Verification

The complete **edit-mode** suite was run and reports no errors.

The **play-mode** tests could not be run: the scene they execute in lacks the
required setup. This is a pre-existing condition, unrelated to this change, and
will be handled in its own issue. Consequently the eight touched play-mode files
are compiled but not executed:

`TestDoTween`, `TestKeywordInput`, `TestMenu`, `TestNestedMenu`,
`TestPropertyDialog`, `TestSEEGame`, `TestSimpleMenu`, `TestUI`

Their changes are of the same kind as the verified edit-mode ones, but that is
an argument, not evidence — they should be run once the scene setup is
available.

Three edit-mode fixtures are also excluded from a plain local run, as before
this change: `TestDataPath`, `TestGit` and `TestGitSEE` need network access or
a GitHub access token.

## Known limitation

`TestGraphIO.WriteReadGraphAsync` asserts that the graph written and the graph
read back are equal, but `Graph.Equals` compares only type, `Name` and `Path`,
and the paths are made equal immediately before. The GXL round-trip therefore
verifies nothing about the graph content. The assertions are migrated with their
semantics unchanged and the situation is documented in a comment at the call
site; making the test meaningful requires a structural graph comparison, which
does not exist in the code base yet. Deferred to a separate issue #983 rather than
stretched into this one.

## Note for the reviewer

Two commits on this branch are unrelated to #981 and were produced by tooling:
`4dc265c76f` (URP update to a Dissonance demo material, triggered through Odin
Validator) and `0e7f4a10fd` (settings written by the HighlightPlus import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)