### PR TITLE
Fix serialization of readonly NetAction fields

### DIFF
--- a/Assets/SEE/Net/Actions/AbstractNetAction.cs
+++ b/Assets/SEE/Net/Actions/AbstractNetAction.cs
@@ -9,7 +9,8 @@ namespace SEE.Net.Actions
     ///
     ///   Rules for every deriving class:
     ///
-    ///     1. Every field MUST be public!
+    ///     1. Every field that needs to be serialized MUST be public and MUST NOT be
+    ///        static, const, or readonly.
     ///     2. Deriving classes MUST NOT have fields of the type GameObjects or
     ///        MonoBehaviours.
     ///

--- a/Assets/SEE/Net/Actions/Animation/AnimationNetAction.cs
+++ b/Assets/SEE/Net/Actions/Animation/AnimationNetAction.cs
@@ -14,7 +14,7 @@ namespace SEE.Net.Actions.Animation
         /// The unique full (hierarchical) name of the gameObject holding an <see cref="AnimationInteraction"/>
         /// component that needs to be triggered.
         /// </summary>
-        public readonly string GameObjectID;
+        public string GameObjectID;
 
         /// <summary>
         /// Constructor.

--- a/Assets/SEE/Net/Actions/GraphElement/ShowInCityNetAction.cs
+++ b/Assets/SEE/Net/Actions/GraphElement/ShowInCityNetAction.cs
@@ -11,7 +11,7 @@ namespace SEE.Net.Actions.GraphElement
         /// <summary>
         /// Duration of the highlight animation in seconds.
         /// </summary>
-        public readonly float Duration;
+        public float Duration;
 
         /// <summary>
         /// Constructor.

--- a/Assets/SEEPlayModeTests/TestNetActionSerialization.cs
+++ b/Assets/SEEPlayModeTests/TestNetActionSerialization.cs
@@ -1,0 +1,81 @@
+﻿using NUnit.Framework;
+using SEE.Net.Actions;
+using SEE.Net.Actions.Animation;
+using SEE.Net.Actions.GraphElement;
+using Unity.Netcode;
+using UnityEngine;
+
+namespace SEE.Net
+{
+    /// <summary>
+    /// Tests serialization and deserialization of network actions.
+    /// </summary>
+    internal class TestNetActionSerialization
+    {
+        /// <summary>
+        /// Game object providing the <see cref="NetworkManager"/> required for constructing network actions.
+        /// </summary>
+        private GameObject networkManagerObject;
+
+        /// <summary>
+        /// Creates the <see cref="NetworkManager"/> required by <see cref="AbstractNetAction"/>.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            networkManagerObject = new GameObject("NetworkManager");
+            networkManagerObject.AddComponent<NetworkManager>();
+        }
+
+        /// <summary>
+        /// Destroys the <see cref="NetworkManager"/> created for the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(networkManagerObject);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="AnimationNetAction.GameObjectID"/> is preserved during serialization
+        /// and deserialization.
+        /// </summary>
+        [Test]
+        public void AnimationNetActionPreservesGameObjectID()
+        {
+            const string gameObjectID = "TestGameObject";
+
+            PressPlayNetAction original = new(gameObjectID);
+
+            string serialized = ActionSerializer.Serialize(original);
+            PressPlayNetAction deserialized
+                = (PressPlayNetAction)ActionSerializer.Deserialize(serialized);
+
+            TestContext.WriteLine($"Serialized JSON: {serialized}");
+
+            Assert.That(deserialized.GameObjectID, Is.EqualTo(gameObjectID));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ShowInCityNetAction.Duration"/> is preserved during serialization
+        /// and deserialization.
+        /// </summary>
+        [Test]
+        public void ShowInCityNetActionPreservesDuration()
+        {
+            const string gameObjectID = "TestGameObject";
+            const float duration = 3.5f;
+
+            ShowInCityNetAction original = new(gameObjectID, duration);
+
+            string serialized = ActionSerializer.Serialize(original);
+            ShowInCityNetAction deserialized
+                = (ShowInCityNetAction)ActionSerializer.Deserialize(serialized);
+
+            TestContext.WriteLine($"Serialized JSON: {serialized}");
+
+            Assert.That(deserialized.GraphElementID, Is.EqualTo(gameObjectID));
+            Assert.That(deserialized.Duration, Is.EqualTo(duration));
+        }
+    }
+}

--- a/Assets/SEEPlayModeTests/TestNetActionSerialization.cs
+++ b/Assets/SEEPlayModeTests/TestNetActionSerialization.cs
@@ -2,8 +2,10 @@
 using SEE.Net.Actions;
 using SEE.Net.Actions.Animation;
 using SEE.Net.Actions.GraphElement;
+using System.Collections;
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace SEE.Net
 {
@@ -29,11 +31,11 @@ namespace SEE.Net
 
         /// <summary>
         /// Destroys the <see cref="NetworkManager"/> created for the test.
-        /// </summary>
-        [TearDown]
-        public void TearDown()
+        [UnityTearDown]
+        public IEnumerator TearDown()
         {
-            Object.DestroyImmediate(networkManagerObject);
+            Object.Destroy(networkManagerObject);
+            yield return null;
         }
 
         /// <summary>
@@ -48,8 +50,7 @@ namespace SEE.Net
             PressPlayNetAction original = new(gameObjectID);
 
             string serialized = ActionSerializer.Serialize(original);
-            PressPlayNetAction deserialized
-                = (PressPlayNetAction)ActionSerializer.Deserialize(serialized);
+            PressPlayNetAction deserialized = (PressPlayNetAction)ActionSerializer.Deserialize(serialized);
 
             TestContext.WriteLine($"Serialized JSON: {serialized}");
 
@@ -63,18 +64,17 @@ namespace SEE.Net
         [Test]
         public void ShowInCityNetActionPreservesDuration()
         {
-            const string gameObjectID = "TestGameObject";
+            const string graphElementID = "TestGraphElement";
             const float duration = 3.5f;
 
-            ShowInCityNetAction original = new(gameObjectID, duration);
+            ShowInCityNetAction original = new(graphElementID, duration);
 
             string serialized = ActionSerializer.Serialize(original);
-            ShowInCityNetAction deserialized
-                = (ShowInCityNetAction)ActionSerializer.Deserialize(serialized);
+            ShowInCityNetAction deserialized = (ShowInCityNetAction)ActionSerializer.Deserialize(serialized);
 
             TestContext.WriteLine($"Serialized JSON: {serialized}");
 
-            Assert.That(deserialized.GraphElementID, Is.EqualTo(gameObjectID));
+            Assert.That(deserialized.GraphElementID, Is.EqualTo(graphElementID));
             Assert.That(deserialized.Duration, Is.EqualTo(duration));
         }
     }

--- a/Assets/SEEPlayModeTests/TestNetActionSerialization.cs.meta
+++ b/Assets/SEEPlayModeTests/TestNetActionSerialization.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93aca08219651ab4cac618cc9e2c4d89


### PR DESCRIPTION
## Summary

This PR fixes two `NetAction` fields that were declared `readonly` and therefore omitted by Unity's `JsonUtility` serialization.

The affected fields are:

`AnimationNetAction.GameObjectID`

`ShowInCityNetAction.Duration`

Both fields are required after deserialization and are now mutable so that they are correctly included in the serialized network action.

## Tests

Added regression tests for both affected fields using the existing `ActionSerializer`.

The tests verify that:

`AnimationNetAction.GameObjectID` survives serialization and deserialization.

`ShowInCityNetAction.Duration` survives serialization and deserialization.

Both tests failed before the fix and pass after removing `readonly`.

Further details about the `JsonUtility` limitation and possible alternatives are documented in #963.

Closes #963
